### PR TITLE
Fix bugs on *nix (Linux in particular)

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -81,15 +81,15 @@ create_test_overlay()
 
   local packageName="Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost.$TestHostVersion.nupkg"
   local packageDir="packages/Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost.$TestHostVersion"
-  #rm -rf $packageDir
-  #mkdir -p $packageDir
-  #pushd $packageDir > /dev/null
+  rm -rf $packageDir
+  mkdir -p $packageDir
+  pushd $packageDir > /dev/null
   # Pull down the testhost package and unzip it.
-  #echo "Pulling down $packageName"
-  #wget -q https://www.myget.org/F/dotnet-buildtools/api/v2/package/Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost/$TestHostVersion -O $packageName
-  #echo "Unzipping to $packageDir"
-  #unzip -q -o $packageName
-  #popd > /dev/null
+  echo "Pulling down $packageName"
+  wget -q https://www.myget.org/F/dotnet-buildtools/api/v2/package/Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost/$TestHostVersion -O $packageName
+  echo "Unzipping to $packageDir"
+  unzip -q -o $packageName
+  popd > /dev/null
 
   # Make the overlay
 

--- a/run-test.sh
+++ b/run-test.sh
@@ -81,15 +81,15 @@ create_test_overlay()
 
   local packageName="Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost.$TestHostVersion.nupkg"
   local packageDir="packages/Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost.$TestHostVersion"
-  rm -rf $packageDir
-  mkdir -p $packageDir
-  pushd $packageDir > /dev/null
+  #rm -rf $packageDir
+  #mkdir -p $packageDir
+  #pushd $packageDir > /dev/null
   # Pull down the testhost package and unzip it.
-  echo "Pulling down $packageName"
-  wget -q https://www.myget.org/F/dotnet-buildtools/api/v2/package/Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost/$TestHostVersion -O $packageName
-  echo "Unzipping to $packageDir"
-  unzip -q -o $packageName
-  popd > /dev/null
+  #echo "Pulling down $packageName"
+  #wget -q https://www.myget.org/F/dotnet-buildtools/api/v2/package/Microsoft.DotNet.CoreFx.$OS.TemporaryTestHost/$TestHostVersion -O $packageName
+  #echo "Unzipping to $packageDir"
+  #unzip -q -o $packageName
+  #popd > /dev/null
 
   # Make the overlay
 

--- a/src/Common/src/Interop/Linux/libc/Interop.SocketFlags.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.SocketFlags.cs
@@ -10,5 +10,6 @@ internal static partial class Interop
         public const int MSG_DONTROUTE = 0x04; // Don't use local routing.
         public const int MSG_CTRUNC = 0x08;    // Control data lost before delivery.
         public const int MSG_TRUNC = 0x20;     // Data lost before delivery.
+        public const int MSG_DONTWAIT = 0x40;  // Use non-blocking I/O.
     }
 }

--- a/src/Common/src/Interop/Linux/libc/Interop.SocketOptionName.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.SocketOptionName.cs
@@ -40,6 +40,7 @@ internal static partial class Interop
 
         public const int IPV6_V6ONLY = 26;
         public const int IPV6_RECVPKTINFO = 49;
+        public const int IPV6_PKTINFO = 50;
 
         public const int TCP_NODELAY = 1;
     }

--- a/src/Common/src/Interop/Linux/libc/Interop.cmsghdr.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.cmsghdr.cs
@@ -10,12 +10,9 @@ internal static partial class Interop
 #pragma warning disable 169, 649
         public unsafe struct cmsghdr
         {
-            public static int Size { get { return sizeof(cmsghdr) - 1; } }
-
             public IntPtr cmsg_len;
             public int cmsg_level;
             public int cmsg_type;
-            public byte cmsg_data; // Actually variably-sized
         }
 #pragma warning restore 169, 649
     }

--- a/src/Common/src/Interop/OSX/libc/Interop.SocketOptionName.cs
+++ b/src/Common/src/Interop/OSX/libc/Interop.SocketOptionName.cs
@@ -39,6 +39,7 @@ internal static partial class Interop
 
         public const int IPV6_V6ONLY = 27;
         public const int IPV6_RECVPKTINFO = 61;
+        public const int IPV6_PKTINFO = 46;
 
         public const int TCP_NODELAY = 0x1;
     }

--- a/src/Common/src/System/Net/Internals/SocketExceptionFactory.cs
+++ b/src/Common/src/System/Net/Internals/SocketExceptionFactory.cs
@@ -12,11 +12,5 @@ namespace System.Net.Internals
             // TODO: expose SocketException(int, EndPoint) to maintain exception Message compatibility.
             return new SocketException(socketError);
         }
-
-        public static SocketException CreateSocketException(EndPoint endPoint)
-        {
-            // TODO: expose SocketException(EndPoint) to maintain exception Message compatibility.
-            return new SocketException();
-        }
     }
 }

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -33,6 +33,8 @@ namespace System.Net.Sockets
         }
 
         public bool IsNonBlocking { get; set; }
+        public int ReceiveTimeout { get; set; }
+        public int SendTimeout { get; set; }
 
         public unsafe static SafeCloseSocket CreateSocket(int fileDescriptor)
         {
@@ -206,7 +208,7 @@ namespace System.Net.Sockets
                 SocketError errorCode;
                 while (!SocketPal.TryCompleteAccept(fd, socketAddress, ref socketAddressSize, out acceptedFd, out errorCode) && !socketHandle.IsNonBlocking)
                 {
-                    if (!SocketPal.Poll(fd, Interop.libc.PollFlags.POLLIN, out errorCode))
+                    if (!SocketPal.Poll(fd, Interop.libc.PollFlags.POLLIN, -1, out errorCode))
                     {
                         break;
                     }

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -230,7 +230,15 @@ namespace System.Net.Sockets
             public static unsafe InnerSafeCloseSocket Accept(SafeCloseSocket socketHandle, byte[] socketAddress, ref int socketAddressLen)
             {
                 int acceptedFd;
-                socketHandle.AsyncContext.Accept(socketAddress, ref socketAddressLen, -1, out acceptedFd);
+                if (!socketHandle.IsNonBlocking)
+                {
+                    socketHandle.AsyncContext.Accept(socketAddress, ref socketAddressLen, -1, out acceptedFd);
+                }
+                else
+                {
+                    SocketError unused;
+                    SocketPal.TryCompleteAccept(socketHandle.FileDescriptor, socketAddress, ref socketAddressLen, out acceptedFd, out unused);
+                }
 
                 var res = new InnerSafeCloseSocket();
                 res.SetHandle((IntPtr)acceptedFd);

--- a/src/Common/tests/System.Net/Sockets/Performance/SocketTestClient.cs
+++ b/src/Common/tests/System.Net/Sockets/Performance/SocketTestClient.cs
@@ -178,8 +178,8 @@ namespace System.Net.Sockets.Performance.Tests
             _recvBufferIndex = 0;
 
             // Expect echo server.
-            if (memcmp(_sendBuffer, _recvBuffer, _sendBuffer.Length) != 0)
-            {
+			if (!Compare(_sendBuffer, _recvBuffer))
+			{
                 _log.WriteLine("Received different data from echo server");
             }
 
@@ -238,9 +238,23 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         protected abstract string ImplementationName();
-        
-        //TODO: Either find a different fast way to compare or extract this in Interop.
-        [DllImport("msvcrt.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int memcmp(byte[] b1, byte[] b2, long count);
+
+		private static bool Compare(byte[] b1, byte[] b2)
+		{
+			if (b1.Length != b2.Length)
+			{
+				return false;
+			}
+
+			for (int i = 0; i < b1.Length; i++)
+			{
+				if (b1[i] != b2[i])
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
     }
 }

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/Disconnect.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/Disconnect.cs
@@ -15,6 +15,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Success()
         {
             AutoResetEvent completed = new AutoResetEvent(false);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DisconnectAsync.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DisconnectAsync.cs
@@ -15,6 +15,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Success()
         {
             AutoResetEvent completed = new AutoResetEvent(false);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DnsEndPointTest.cs
@@ -7,13 +7,15 @@ namespace System.Net.Sockets.Tests
 {
     public class DnsEndPointTest
     {
+        private const int TestPortBase = 8080;
+
         [Fact]
         public void Socket_ConnectDnsEndPoint_Success()
         {
-            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, 8080));
+            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, TestPortBase));
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            sock.Connect(new DnsEndPoint("localhost", 8080));
+            sock.Connect(new DnsEndPoint("localhost", TestPortBase));
 
             sock.Dispose();
             server.Dispose();
@@ -26,7 +28,7 @@ namespace System.Net.Sockets.Tests
             {
                 // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 SocketException ex = Assert.ThrowsAny<SocketException>(() => {
-                    sock.Connect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", 8080));
+                    sock.Connect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", TestPortBase + 1));
                 });
 
                 SocketError errorCode = ex.SocketErrorCode;
@@ -35,7 +37,7 @@ namespace System.Net.Sockets.Tests
 
                 // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 ex = Assert.ThrowsAny<SocketException>(() => {
-                    sock.Connect(new DnsEndPoint("localhost", 8081));
+                    sock.Connect(new DnsEndPoint("localhost", TestPortBase + 2));
                 });
 
                 Assert.Equal(SocketError.ConnectionRefused, ex.SocketErrorCode);
@@ -48,7 +50,7 @@ namespace System.Net.Sockets.Tests
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
                 Assert.Throws<ArgumentException>(() => {
-                    sock.SendTo(new byte[10], new DnsEndPoint("localhost", 8080));
+                    sock.SendTo(new byte[10], new DnsEndPoint("localhost", TestPortBase + 3));
                 });
             }
         }
@@ -58,8 +60,8 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
-                sock.Bind(new IPEndPoint(IPAddress.Loopback, 8080));
-                EndPoint endpoint = new DnsEndPoint("localhost", 8080);
+                sock.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 4));
+                EndPoint endpoint = new DnsEndPoint("localhost", TestPortBase + 4);
 
                 Assert.Throws<ArgumentException>(() => {
                     sock.ReceiveFrom(new byte[10], ref endpoint);
@@ -70,10 +72,10 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void Socket_BeginConnectDnsEndPoint_Success()
         {
-            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, 8080));
+            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, TestPortBase + 5));
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            IAsyncResult result = sock.BeginConnect(new DnsEndPoint("localhost", 8080), null, null);
+            IAsyncResult result = sock.BeginConnect(new DnsEndPoint("localhost", TestPortBase + 5), null, null);
             sock.EndConnect(result);
 
             sock.Dispose();
@@ -87,7 +89,7 @@ namespace System.Net.Sockets.Tests
             {
                 // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 SocketException ex = Assert.ThrowsAny<SocketException>(() => {
-                    IAsyncResult result = sock.BeginConnect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", 8080), null, null);
+                    IAsyncResult result = sock.BeginConnect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", TestPortBase + 6), null, null);
                     sock.EndConnect(result);
                 });
 
@@ -97,7 +99,7 @@ namespace System.Net.Sockets.Tests
 
                 // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 ex = Assert.ThrowsAny<SocketException>(() => {
-                    IAsyncResult result = sock.BeginConnect(new DnsEndPoint("localhost", 8080), null, null);
+                    IAsyncResult result = sock.BeginConnect(new DnsEndPoint("localhost", TestPortBase + 6), null, null);
                     sock.EndConnect(result);
                 });
 
@@ -111,7 +113,7 @@ namespace System.Net.Sockets.Tests
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
                 Assert.Throws<ArgumentException>(() => {
-                    sock.BeginSendTo(new byte[10], 0, 0, SocketFlags.None, new DnsEndPoint("localhost", 8080), null, null);
+                    sock.BeginSendTo(new byte[10], 0, 0, SocketFlags.None, new DnsEndPoint("localhost", TestPortBase + 7), null, null);
                 });
             }
         }
@@ -125,10 +127,10 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void Socket_ConnectAsyncDnsEndPoint_Success()
         {
-            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, 8080));
+            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, TestPortBase + 8));
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 8);
             args.Completed += OnConnectAsyncCompleted;
             
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -151,7 +153,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_ConnectAsyncDnsEndPoint_HostNotFound()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", TestPortBase + 9);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -172,7 +174,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_ConnectAsyncDnsEndPoint_ConnectionRefused()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 10);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -197,11 +199,11 @@ namespace System.Net.Sockets.Tests
 
             Assert.True(Capability.IPv6Support() && Capability.IPv4Support());
 
-            SocketTestServer server4 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, 8080));
-            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.IPv6Loopback, 8081));
+            SocketTestServer server4 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, TestPortBase + 11));
+            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 12));
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 11);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -219,7 +221,7 @@ namespace System.Net.Sockets.Tests
 
             args.ConnectSocket.Dispose();
 
-            args.RemoteEndPoint = new DnsEndPoint("localhost", 8081);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 12);
             complete.Reset();
 
             Assert.True(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));
@@ -242,7 +244,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_StaticConnectAsync_HostNotFound()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", TestPortBase + 13);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -263,7 +265,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_StaticConnectAsync_ConnectionRefused()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 14);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -292,7 +294,7 @@ namespace System.Net.Sockets.Tests
             Assert.True(Capability.IPv6Support()); // IPv6 required because we use AF.InterNetworkV6
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("127.0.0.1", 8080, AddressFamily.InterNetworkV6);
+            args.RemoteEndPoint = new DnsEndPoint("127.0.0.1", TestPortBase + 15, AddressFamily.InterNetworkV6);
             args.Completed += CallbackThatShouldNotBeCalled;
 
             Assert.False(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -377,7 +377,7 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 6))
             {
-                socket.Connect("loopback", TestPortBase + 6);
+                socket.Connect("localhost", TestPortBase + 6);
                 Assert.True(socket.Connected);
             }
         }
@@ -409,7 +409,7 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 49))
             {
-                socket.Connect(new DnsEndPoint("loopback", TestPortBase + 49, addressFamily));
+                socket.Connect(new DnsEndPoint("localhost", TestPortBase + 49, addressFamily));
                 Assert.True(socket.Connected);
             }
         }
@@ -640,7 +640,7 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 11))
             {
-                IAsyncResult async = socket.BeginConnect("loopback", TestPortBase + 11, null, null);
+                IAsyncResult async = socket.BeginConnect("localhost", TestPortBase + 11, null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -673,7 +673,7 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 50))
             {
-                IAsyncResult async = socket.BeginConnect(new DnsEndPoint("loopback", TestPortBase + 50), null, null);
+                IAsyncResult async = socket.BeginConnect(new DnsEndPoint("localhost", TestPortBase + 50), null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -792,7 +792,7 @@ namespace System.Net.Sockets.Tests
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.Completed += new EventHandler<SocketAsyncEventArgs>(AsyncCompleted);
-                args.RemoteEndPoint = new DnsEndPoint("loopback", TestPortBase + 51);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 51);
                 args.UserToken = waitHandle;
 
                 socket.ConnectAsync(args);
@@ -862,7 +862,7 @@ namespace System.Net.Sockets.Tests
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
                 Assert.Throws<ArgumentException>( () => {
-                    socket.Bind(new DnsEndPoint("loopback", TestPortBase + 52));
+                    socket.Bind(new DnsEndPoint("localhost", TestPortBase + 52));
                 });
             }
         }

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -8,6 +8,9 @@ namespace System.Net.Sockets.Tests
 {
     public class DualMode
     {
+        private const int DummyDualModeV6Issue = 8000;
+        private const int DummyErrorMismatchIssue = 8001;
+
         private const int TestPortBase = 8200;  // to 8300
         private readonly ITestOutputHelper _log;
 
@@ -74,32 +77,32 @@ namespace System.Net.Sockets.Tests
         [Fact] // Base Case
         public void ConnectV4MappedIPAddressToV4Host_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, false);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, false, TestPortBase + 1);
         }
 
         [Fact] // Base Case
         public void ConnectV4MappedIPAddressToDualHost_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.IPv6Any, true);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.IPv6Any, true, TestPortBase + 2);
         }
 
         [Fact]
         public void ConnectV4IPAddressToV4Host_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 3);
         }
 
         [Fact]
         public void ConnectV6IPAddressToV6Host_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 4);
         }
 
         [Fact]
         public void ConnectV4IPAddressToV6Host_Fails()
         {
-            Assert.Throws<SocketException>( () => { 
-                DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+            Assert.Throws<SocketException>(() => { 
+                DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 5);
             });
         }
 
@@ -107,28 +110,28 @@ namespace System.Net.Sockets.Tests
         public void ConnectV6IPAddressToV4Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 6);
             });
         }
 
         [Fact]
         public void ConnectV4IPAddressToDualHost_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 7);
         }
 
         [Fact]
         public void ConnectV6IPAddressToDualHost_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 8);
         }
 
-        private void DualModeConnect_IPAddressToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnect_IPAddressToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 1))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                socket.Connect(connectTo, TestPortBase + 1);
+                socket.Connect(connectTo, port);
                 Assert.True(socket.Connected);
             }
         }
@@ -144,39 +147,39 @@ namespace System.Net.Sockets.Tests
             socket.DualMode = false;
 
             Assert.Throws<SocketException>(() => {
-                socket.Connect(new IPEndPoint(IPAddress.Loopback, TestPortBase + 2));
+                socket.Connect(new IPEndPoint(IPAddress.Loopback, TestPortBase + 10));
             });
         }
 
         [Fact] // Base case
         public void ConnectV4MappedIPEndPointToV4Host_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, false);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, false, TestPortBase + 11);
         }
 
         [Fact] // Base case
         public void ConnectV4MappedIPEndPointToDualHost_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.IPv6Any, true);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.IPv6Any, true, TestPortBase + 12);
         }
 
         [Fact]
         public void ConnectV4IPEndPointToV4Host_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 13);
         }
 
         [Fact]
         public void ConnectV6IPEndPointToV6Host_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 14);
         }
 
         [Fact]
         public void ConnectV4IPEndPointToV6Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 15);
             });
         }
 
@@ -184,28 +187,28 @@ namespace System.Net.Sockets.Tests
         public void ConnectV6IPEndPointToV4Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 16);
             });
         }
 
         [Fact]
         public void ConnectV4IPEndPointToDualHost_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 17);
         }
 
         [Fact]
         public void ConnectV6IPEndPointToDualHost_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 18);
         }
 
-        private void DualModeConnect_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnect_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 3))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {                
-                socket.Connect(new IPEndPoint(connectTo, TestPortBase + 3));
+                socket.Connect(new IPEndPoint(connectTo, port));
                 Assert.True(socket.Connected);
             }
         }
@@ -220,10 +223,10 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             socket.DualMode = false;
-            using (SocketServer server = new SocketServer(_log, IPAddress.Loopback, false, TestPortBase + 4))
+            using (SocketServer server = new SocketServer(_log, IPAddress.Loopback, false, TestPortBase + 20))
             {
                 Assert.Throws<ArgumentException>(() => {
-                    socket.Connect(new IPAddress[] { IPAddress.Loopback }, TestPortBase + 4);
+                    socket.Connect(new IPAddress[] { IPAddress.Loopback }, TestPortBase + 20);
                 });
             }
         }
@@ -233,7 +236,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback.MapToIPv6() },
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 21);
         }
 
         [Fact]
@@ -242,7 +245,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<SocketException>(() => {
                 DualModeConnect_IPAddressListToHost_Helper(
                     new IPAddress[] { IPAddress.Loopback.MapToIPv6() },
-                    IPAddress.IPv6Loopback, false);
+                    IPAddress.IPv6Loopback, false, TestPortBase + 22);
             });
         }
 
@@ -251,7 +254,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback },
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 23);
         }
 
         [Fact]
@@ -260,7 +263,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<SocketException>(() => {
                 DualModeConnect_IPAddressListToHost_Helper(
                     new IPAddress[] { IPAddress.Loopback },
-                    IPAddress.IPv6Loopback, false);
+                    IPAddress.IPv6Loopback, false, TestPortBase + 24);
             });
         }
 
@@ -270,7 +273,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<SocketException>(() => {
                 DualModeConnect_IPAddressListToHost_Helper(
                     new IPAddress[] { IPAddress.Loopback },
-                    IPAddress.IPv6Any, false);
+                    IPAddress.IPv6Any, false, TestPortBase + 25);
             });
         }
 
@@ -280,7 +283,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<SocketException>(() => {
                 DualModeConnect_IPAddressListToHost_Helper(
                     new IPAddress[] { IPAddress.Loopback },
-                    IPAddress.IPv6Loopback, true);
+                    IPAddress.IPv6Loopback, true, TestPortBase + 26);
             });
         }
 
@@ -289,7 +292,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback },
-                IPAddress.IPv6Any, true);
+                IPAddress.IPv6Any, true, TestPortBase + 27);
         }
         
         [Fact]
@@ -297,7 +300,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback }, 
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 28);
         }
 
         [Fact]
@@ -305,7 +308,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 29);
         }
 
         [Fact]
@@ -313,7 +316,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback },
-                IPAddress.IPv6Loopback, false);
+                IPAddress.IPv6Loopback, false, TestPortBase + 30);
         }
 
         [Fact]
@@ -321,7 +324,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.IPv6Loopback, false);
+                IPAddress.IPv6Loopback, false, TestPortBase + 31);
         }
 
         [Fact]
@@ -329,7 +332,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback },
-                IPAddress.IPv6Any, true);
+                IPAddress.IPv6Any, true, TestPortBase + 32);
         }
 
         [Fact]
@@ -337,15 +340,15 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.IPv6Any, true);
+                IPAddress.IPv6Any, true, TestPortBase + 33);
         }
 
-        private void DualModeConnect_IPAddressListToHost_Helper(IPAddress[] connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnect_IPAddressListToHost_Helper(IPAddress[] connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 5))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                socket.Connect(connectTo, TestPortBase + 5);
+                socket.Connect(connectTo, port);
                 Assert.True(socket.Connected);
             }
         }
@@ -357,27 +360,27 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ConnectLoopbackToV4Host_Success()
         {
-            DualModeConnect_LoopackDnsToHost_Helper(IPAddress.Loopback, false);
+            DualModeConnect_LoopbackDnsToHost_Helper(IPAddress.Loopback, false, TestPortBase + 40);
         }
 
         [Fact]
         public void ConnectLoopbackToV6Host_Success()
         {
-            DualModeConnect_LoopackDnsToHost_Helper(IPAddress.IPv6Loopback, false);
+            DualModeConnect_LoopbackDnsToHost_Helper(IPAddress.IPv6Loopback, false, TestPortBase + 41);
         }
 
         [Fact]
         public void ConnectLoopbackToDualHost_Success()
         {
-            DualModeConnect_LoopackDnsToHost_Helper(IPAddress.IPv6Any, true);
+            DualModeConnect_LoopbackDnsToHost_Helper(IPAddress.IPv6Any, true, TestPortBase + 42);
         }
 
-        private void DualModeConnect_LoopackDnsToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnect_LoopbackDnsToHost_Helper(IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 6))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                socket.Connect("localhost", TestPortBase + 6);
+                socket.Connect("localhost", port);
                 Assert.True(socket.Connected);
             }
         }
@@ -389,27 +392,27 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void DualModeSocket_DnsEndPointToV4Host_Success()
         {
-            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.Loopback, false, AddressFamily.Unspecified);
+            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.Loopback, false, AddressFamily.Unspecified, TestPortBase + 50);
         }
 
         [Fact]
         public void DualModeSocket_DnsEndPointToV6Host_Success()
         {
-            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false, AddressFamily.Unspecified);
+            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false, AddressFamily.Unspecified, TestPortBase + 51);
         }
 
         [Fact]
         public void DualModeSocket_DnsEndPointToDualHost_Success()
         {
-            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true, AddressFamily.Unspecified);
+            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true, AddressFamily.Unspecified, TestPortBase + 52);
         }
 
-        private void DualModeConnect_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer, AddressFamily addressFamily)
+        private void DualModeConnect_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer, AddressFamily addressFamily, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 49))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                socket.Connect(new DnsEndPoint("localhost", TestPortBase + 49, addressFamily));
+                socket.Connect(new DnsEndPoint("localhost", port, addressFamily));
                 Assert.True(socket.Connected);
             }
         }
@@ -429,27 +432,27 @@ namespace System.Net.Sockets.Tests
             socket.DualMode = false;
 
             Assert.Throws<NotSupportedException>(() => {
-                socket.BeginConnect(IPAddress.Loopback, TestPortBase + 39, null, null);
+                socket.BeginConnect(IPAddress.Loopback, TestPortBase + 60, null, null);
             });
         }
 
         [Fact]
         public void BeginConnectV4IPAddressToV4Host_Success()
         {
-            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 61);
         }
 
         [Fact]
         public void BeginConnectV6IPAddressToV6Host_Success()
         {
-            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 62);
         }
 
         [Fact]
         public void BeginConnectV4IPAddressToV6Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 63);
             });
         }
 
@@ -457,28 +460,28 @@ namespace System.Net.Sockets.Tests
         public void BeginConnectV6IPAddressToV4Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 64);
             });
         }
 
         [Fact]
         public void BeginConnectV4IPAddressToDualHost_Success()
         {
-            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 65);
         }
 
         [Fact]
         public void BeginConnectV6IPAddressToDualHost_Success()
         {
-            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 66);
         }
 
-        private void DualModeBeginConnect_IPAddressToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginConnect_IPAddressToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 7))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                IAsyncResult async = socket.BeginConnect(connectTo, TestPortBase + 7, null, null);
+                IAsyncResult async = socket.BeginConnect(connectTo, port, null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -495,27 +498,27 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             socket.DualMode = false;
             Assert.Throws<SocketException>(() => {
-                socket.BeginConnect(new IPEndPoint(IPAddress.Loopback, TestPortBase + 8), null, null);
+                socket.BeginConnect(new IPEndPoint(IPAddress.Loopback, TestPortBase + 70), null, null);
             });
         }
 
         [Fact]
         public void BeginConnectV4IPEndPointToV4Host_Success()
         {
-            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 71);
         }
 
         [Fact]
         public void BeginConnectV6IPEndPointToV6Host_Success()
         {
-            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 72);
         }
 
         [Fact]
         public void BeginConnectV4IPEndPointToV6Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 73);
             });
         }
 
@@ -523,28 +526,28 @@ namespace System.Net.Sockets.Tests
         public void BeginConnectV6IPEndPointToV4Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 74);
             });
         }
 
         [Fact]
         public void BeginConnectV4IPEndPointToDualHost_Success()
         {
-            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 75);
         }
 
         [Fact]
         public void BeginConnectV6IPEndPointToDualHost_Success()
         {
-            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 76);
         }
 
-        private void DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 9))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                IAsyncResult async = socket.BeginConnect(new IPEndPoint(connectTo, TestPortBase + 9), null, null);
+                IAsyncResult async = socket.BeginConnect(new IPEndPoint(connectTo, port), null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -559,7 +562,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback },
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 80);
         }
 
         [Fact]
@@ -567,7 +570,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 81);
         }
 
         [Fact]
@@ -575,7 +578,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback },
-                IPAddress.IPv6Loopback, false);
+                IPAddress.IPv6Loopback, false, TestPortBase + 82);
         }
 
         [Fact]
@@ -583,7 +586,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.IPv6Loopback, false);
+                IPAddress.IPv6Loopback, false, TestPortBase + 83);
         }
 
         [Fact]
@@ -591,7 +594,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback },
-                IPAddress.IPv6Any, true);
+                IPAddress.IPv6Any, true, TestPortBase + 84);
         }
 
         [Fact]
@@ -599,15 +602,15 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.IPv6Any, true);
+                IPAddress.IPv6Any, true, TestPortBase + 85);
         }
 
-        private void DualModeBeginConnect_IPAddressListToHost_Helper(IPAddress[] connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginConnect_IPAddressListToHost_Helper(IPAddress[] connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 10))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                IAsyncResult async = socket.BeginConnect(connectTo, TestPortBase + 10, null, null);
+                IAsyncResult async = socket.BeginConnect(connectTo, port, null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -620,27 +623,27 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void BeginConnectLoopbackToV4Host_Success()
         {
-            DualModeBeginConnect_LoopackDnsToHost_Helper(IPAddress.Loopback, false);
+            DualModeBeginConnect_LoopbackDnsToHost_Helper(IPAddress.Loopback, false, TestPortBase + 90);
         }
 
         [Fact]
         public void BeginConnectLoopbackToV6Host_Success()
         {
-            DualModeBeginConnect_LoopackDnsToHost_Helper(IPAddress.IPv6Loopback, false);
+            DualModeBeginConnect_LoopbackDnsToHost_Helper(IPAddress.IPv6Loopback, false, TestPortBase + 91);
         }
 
         [Fact]
         public void BeginConnectLoopbackToDualHost_Success()
         {
-            DualModeBeginConnect_LoopackDnsToHost_Helper(IPAddress.IPv6Any, true);
+            DualModeBeginConnect_LoopbackDnsToHost_Helper(IPAddress.IPv6Any, true, TestPortBase + 92);
         }
 
-        private void DualModeBeginConnect_LoopackDnsToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginConnect_LoopbackDnsToHost_Helper(IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 11))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                IAsyncResult async = socket.BeginConnect("localhost", TestPortBase + 11, null, null);
+                IAsyncResult async = socket.BeginConnect("localhost", port, null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -653,27 +656,27 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void DualModeSocket_BeginConnectDnsEndPointToV4Host_Success()
         {
-            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.Loopback, false);
+            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.Loopback, false, TestPortBase + 100);
         }
 
         [Fact]
         public void DualModeSocket_BeginConnectDnsEndPointToV6Host_Success()
         {
-            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false);
+            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false, TestPortBase + 101);
         }
 
         [Fact]
         public void DualModeSocket_BeginConnectDnsEndPointToDualHost_Success()
         {
-            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true);
+            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true, TestPortBase + 102);
         }
 
-        private void DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 50))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                IAsyncResult async = socket.BeginConnect(new DnsEndPoint("localhost", TestPortBase + 50), null, null);
+                IAsyncResult async = socket.BeginConnect(new DnsEndPoint("localhost", port), null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -694,7 +697,7 @@ namespace System.Net.Sockets.Tests
             socket.DualMode = false;
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 12);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 110);
             Assert.Throws<NotSupportedException>(() => {
                 socket.ConnectAsync(args);
             });
@@ -703,20 +706,20 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ConnectAsyncV4IPEndPointToV4Host_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 111);
         }
 
         [Fact]
         public void ConnectAsyncV6IPEndPointToV6Host_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 112);
         }
 
         [Fact]
         public void ConnectAsyncV4IPEndPointToV6Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 113);
             });
         }
 
@@ -724,31 +727,31 @@ namespace System.Net.Sockets.Tests
         public void ConnectAsyncV6IPEndPointToV4Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 114);
             });
         }
 
         [Fact]
         public void ConnectAsyncV4IPEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 115);
         }
 
         [Fact]
         public void ConnectAsyncV6IPEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 116);
         }
 
-        private void DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 13))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.Completed += new EventHandler<SocketAsyncEventArgs>(AsyncCompleted);
-                args.RemoteEndPoint = new IPEndPoint(connectTo, TestPortBase + 13);
+                args.RemoteEndPoint = new IPEndPoint(connectTo, port);
                 args.UserToken = waitHandle;
 
                 socket.ConnectAsync(args);
@@ -769,30 +772,30 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToV4Host_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.Loopback, false);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.Loopback, false, TestPortBase + 120);
         }
 
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToV6Host_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false, TestPortBase + 121);
         }
 
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true, TestPortBase + 122);
         }
 
-        private void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 51))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.Completed += new EventHandler<SocketAsyncEventArgs>(AsyncCompleted);
-                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 51);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", port);
                 args.UserToken = waitHandle;
 
                 socket.ConnectAsync(args);
@@ -824,7 +827,7 @@ namespace System.Net.Sockets.Tests
             {
                 socket.DualMode = false;
                 Assert.Throws<SocketException>(() => {
-                    socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 14));
+                    socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 130));
                 });
             }
         }
@@ -834,7 +837,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.Loopback.MapToIPv6(), TestPortBase + 15));
+                socket.Bind(new IPEndPoint(IPAddress.Loopback.MapToIPv6(), TestPortBase + 131));
             }
         }
 
@@ -843,7 +846,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 16));
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 132));
             }
         }
 
@@ -852,7 +855,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 17));
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 133));
             }
         }
 
@@ -862,7 +865,7 @@ namespace System.Net.Sockets.Tests
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
                 Assert.Throws<ArgumentException>( () => {
-                    socket.Bind(new DnsEndPoint("localhost", TestPortBase + 52));
+                    socket.Bind(new DnsEndPoint("localhost", TestPortBase + 134));
                 });
             }
         }
@@ -874,7 +877,7 @@ namespace System.Net.Sockets.Tests
             using (Socket serverSocket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
                 serverSocket.DualMode = false;
-                serverSocket.Bind(new IPEndPoint(IPAddress.IPv6Any, TestPortBase + 18));
+                serverSocket.Bind(new IPEndPoint(IPAddress.IPv6Any, TestPortBase + 135));
                 Assert.Throws<SocketException>(() => {
                     serverSocket.DualMode = true;
                 });
@@ -888,32 +891,33 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void AcceptV4BoundToSpecificV4_Success()
         {
-            Accept_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            Accept_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 140);
         }
 
         [Fact]
         public void AcceptV4BoundToAnyV4_Success()
         {
-            Accept_Helper(IPAddress.Any, IPAddress.Loopback);
+            Accept_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 141);
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void AcceptV6BoundToSpecificV6_Success()
         {
-            Accept_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            Accept_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 142);
         }
 
         [Fact]
         public void AcceptV6BoundToAnyV6_Success()
         {
-            Accept_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            Accept_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 143);
         }
 
         [Fact]
         public void AcceptV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                Accept_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                Accept_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 144);
             });
         }
 
@@ -921,7 +925,7 @@ namespace System.Net.Sockets.Tests
         public void AcceptV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                Accept_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                Accept_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 145);
             });
         }
 
@@ -929,23 +933,23 @@ namespace System.Net.Sockets.Tests
         public void AcceptV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                Accept_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                Accept_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 146);
             });
         }
 
         [Fact]
         public void AcceptV4BoundToAnyV6_Success()
         {
-            Accept_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            Accept_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 147);
         }
         
-        private void Accept_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void Accept_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 19));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
                 serverSocket.Listen(1);
-                SocketClient client = new SocketClient(serverSocket, connectTo, TestPortBase + 19);
+                SocketClient client = new SocketClient(serverSocket, connectTo, port);
                 Socket clientSocket = serverSocket.Accept();
                 Assert.True(clientSocket.Connected);
                 Assert.True(clientSocket.DualMode);
@@ -960,32 +964,33 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void BeginAcceptV4BoundToSpecificV4_Success()
         {
-            DualModeConnect_BeginAccept_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            DualModeConnect_BeginAccept_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 150);
         }
 
         [Fact]
         public void BeginAcceptV4BoundToAnyV4_Success()
         {
-            DualModeConnect_BeginAccept_Helper(IPAddress.Any, IPAddress.Loopback);
+            DualModeConnect_BeginAccept_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 151);
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void BeginAcceptV6BoundToSpecificV6_Success()
         {
-            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 152);
         }
 
         [Fact]
         public void BeginAcceptV6BoundToAnyV6_Success()
         {
-            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 153);
         }
 
         [Fact]
         public void BeginAcceptV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_BeginAccept_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                DualModeConnect_BeginAccept_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 154);
             });
         }
 
@@ -993,7 +998,7 @@ namespace System.Net.Sockets.Tests
         public void BeginAcceptV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 155);
             });
         }
 
@@ -1001,24 +1006,24 @@ namespace System.Net.Sockets.Tests
         public void BeginAcceptV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_BeginAccept_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                DualModeConnect_BeginAccept_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 156);
             });
         }
 
         [Fact]
         public void BeginAcceptV4BoundToAnyV6_Success()
         {
-            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 157);
         }
 
-        private void DualModeConnect_BeginAccept_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void DualModeConnect_BeginAccept_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 20));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
                 serverSocket.Listen(1);
                 IAsyncResult async = serverSocket.BeginAccept(null, null);
-                SocketClient client = new SocketClient(serverSocket, connectTo, TestPortBase + 20);
+                SocketClient client = new SocketClient(serverSocket, connectTo, port);
                 Socket clientSocket = serverSocket.EndAccept(async);
                 Assert.True(clientSocket.Connected);
                 Assert.True(clientSocket.DualMode);
@@ -1034,32 +1039,33 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void AcceptAsyncV4BoundToSpecificV4_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 41);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 160);
         }
 
         [Fact]
         public void AcceptAsyncV4BoundToAnyV4_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 42);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 161);
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void AcceptAsyncV6BoundToSpecificV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 43);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 162);
         }
 
         [Fact]
         public void AcceptAsyncV6BoundToAnyV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 44);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 163);
         }
 
         [Fact]
         public void AcceptAsyncV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 45);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 164);
             });
         }
 
@@ -1067,7 +1073,7 @@ namespace System.Net.Sockets.Tests
         public void AcceptAsyncV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 46);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 165);
             });
         }
 
@@ -1075,14 +1081,14 @@ namespace System.Net.Sockets.Tests
         public void AcceptAsyncV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 47);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 166);
             });
         }
 
         [Fact]
         public void AcceptAsyncV4BoundToAnyV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 48);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 167);
         }
 
         private void DualModeConnect_AcceptAsync_Helper(IPAddress listenOn, IPAddress connectTo, int port)
@@ -1142,7 +1148,7 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
             Assert.Throws<SocketException>(() => {
-                socket.SendTo(new byte[1], new IPEndPoint(IPAddress.Loopback, TestPortBase + 40));
+                socket.SendTo(new byte[1], new IPEndPoint(IPAddress.Loopback, TestPortBase + 170));
             });
         }
 
@@ -1152,27 +1158,27 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             Assert.Throws<ArgumentException>(() => {
-                socket.SendTo(new byte[1], new DnsEndPoint("localhost", TestPortBase + 59));
+                socket.SendTo(new byte[1], new DnsEndPoint("localhost", TestPortBase + 171));
             });
         }
         
         [Fact]
         public void SendToV4IPEndPointToV4Host_Success()
         {
-            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 172);
         }
 
         [Fact]
         public void SendToV6IPEndPointToV6Host_Success()
         {
-            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 173);
         }
 
         [Fact]
         public void SendToV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 174);
             });
         }
 
@@ -1180,28 +1186,28 @@ namespace System.Net.Sockets.Tests
         public void SendToV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 175);
             });
         }
 
         [Fact]
         public void SendToV4IPEndPointToDualHost_Success()
         {
-            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 176);
         }
 
         [Fact]
         public void SendToV6IPEndPointToDualHost_Success()
         {
-            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 177);
         }
 
-        private void DualModeSendTo_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeSendTo_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket client = new Socket(SocketType.Dgram, ProtocolType.Udp);
-            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, TestPortBase + 22))
+            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, port))
             {
-                int sent = client.SendTo(new byte[1], new IPEndPoint(connectTo, TestPortBase + 22));
+                int sent = client.SendTo(new byte[1], new IPEndPoint(connectTo, port));
                 Assert.Equal(1, sent); 
 
                 bool success = server.WaitHandle.WaitOne(500); // Make sure the bytes were received
@@ -1224,7 +1230,7 @@ namespace System.Net.Sockets.Tests
             socket.DualMode = false;
 
             Assert.Throws<SocketException>(() => {
-                socket.BeginSendTo(new byte[1], 0, 1, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, TestPortBase + 23),
+                socket.BeginSendTo(new byte[1], 0, 1, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, TestPortBase + 180),
                 null, null);
             });
         }
@@ -1236,27 +1242,27 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
 
             Assert.Throws<ArgumentException>( () => {
-                socket.BeginSendTo(new byte[1], 0, 1, SocketFlags.None, new DnsEndPoint("localhost", TestPortBase + 61), null, null);
+                socket.BeginSendTo(new byte[1], 0, 1, SocketFlags.None, new DnsEndPoint("localhost", TestPortBase + 181), null, null);
             });
         }
 
         [Fact]
         public void BeginSendToV4IPEndPointToV4Host_Success()
         {
-            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 182);
         }
 
         [Fact]
         public void BeginSendToV6IPEndPointToV6Host_Success()
         {
-            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 183);
         }
 
         [Fact]
         public void BeginSendToV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 184);
             });
         }
 
@@ -1264,29 +1270,29 @@ namespace System.Net.Sockets.Tests
         public void BeginSendToV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 185);
             });
         }
 
         [Fact]
         public void BeginSendToV4IPEndPointToDualHost_Success()
         {
-            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 186);
         }
 
         [Fact]
         public void BeginSendToV6IPEndPointToDualHost_Success()
         {
-            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 187);
         }
 
-        private void DualModeBeginSendTo_EndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginSendTo_EndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket client = new Socket(SocketType.Dgram, ProtocolType.Udp);
-            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, TestPortBase + 24))
+            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, port))
             {
                 IAsyncResult async = client.BeginSendTo(new byte[1], 0, 1, SocketFlags.None,
-                    new IPEndPoint(connectTo, TestPortBase + 24), null, null);
+                    new IPEndPoint(connectTo, port), null, null);
                 int sent = client.EndSendTo(async);
                 Assert.Equal(1, sent);
                 bool success = server.WaitHandle.WaitOne(100); // Make sure the bytes were received
@@ -1302,12 +1308,13 @@ namespace System.Net.Sockets.Tests
         #region SendTo Async/Event
 
         [Fact] // Base case
+        [ActiveIssue(DummyErrorMismatchIssue, PlatformID.AnyUnix)]
         public void Socket_SendToAsyncV4IPEndPointToV4Host_Throws()
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 25);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 190);
             args.SetBuffer(new byte[1], 0, 1);
             bool async = socket.SendToAsync(args);
             Assert.False(async);
@@ -1320,7 +1327,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 53);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 191);
             args.SetBuffer(new byte[1], 0, 1);
 
             Assert.Throws<ArgumentException>(() => {
@@ -1331,20 +1338,20 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void SendToAsyncV4IPEndPointToV4Host_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 192);
         }
 
         [Fact]
         public void SendToAsyncV6IPEndPointToV6Host_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 193);
         }
 
         [Fact]
         public void SendToAsyncV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 194);
             });
         }
 
@@ -1352,30 +1359,30 @@ namespace System.Net.Sockets.Tests
         public void SendToAsyncV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 195);
             });
         }
 
         [Fact]
         public void SendToAsyncV4IPEndPointToDualHost_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 196);
         }
 
         [Fact]
         public void SendToAsyncV6IPEndPointToDualHost_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 197);
         }
 
-        private void DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             ManualResetEvent waitHandle = new ManualResetEvent(false);
             Socket client = new Socket(SocketType.Dgram, ProtocolType.Udp);
-            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, TestPortBase + 26))
+            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, port))
             {
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(connectTo, TestPortBase + 26);
+                args.RemoteEndPoint = new IPEndPoint(connectTo, port);
                 args.SetBuffer(new byte[1], 0, 1);
                 args.UserToken = waitHandle;
                 args.Completed += AsyncCompleted;
@@ -1413,7 +1420,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
-            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 27);
+            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 200);
             Assert.Throws<ArgumentException>(() => {
                 int received = socket.ReceiveFrom(new byte[1], ref receivedFrom);
             });
@@ -1425,8 +1432,8 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 54, AddressFamily.InterNetworkV6);
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 54));
+                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 201, AddressFamily.InterNetworkV6);
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 201));
                 Assert.Throws<ArgumentException>(() => {
                     int received = socket.ReceiveFrom(new byte[1], ref receivedFrom);
                 });
@@ -1436,40 +1443,41 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ReceiveFromV4BoundToSpecificV4_Success()
         {
-            ReceiveFrom_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            ReceiveFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 202);
         }
 
         [Fact]
         public void ReceiveFromV4BoundToAnyV4_Success()
         {
-            ReceiveFrom_Helper(IPAddress.Any, IPAddress.Loopback);
+            ReceiveFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 203);
         }
 
         [Fact]
         public void ReceiveFromV6BoundToSpecificV6_Success()
         {
-            ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 204);
         }
 
         [Fact]
         public void ReceiveFromV6BoundToAnyV6_Success()
         {
-            ReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            ReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 205);
         }
 
         [Fact]
         public void ReceiveFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<SocketException>(() => {
-                ReceiveFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                ReceiveFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 206);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void ReceiveFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<SocketException>( () => { 
-                ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 207);
             });
         }
 
@@ -1477,25 +1485,25 @@ namespace System.Net.Sockets.Tests
         public void ReceiveFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<SocketException>(() => {
-                ReceiveFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                ReceiveFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 208);
             });
         }
 
         [Fact]
         public void ReceiveFromV4BoundToAnyV6_Success()
         {
-            ReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            ReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 209);
         }
 
-        private void ReceiveFrom_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void ReceiveFrom_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
                 serverSocket.ReceiveTimeout = 500;
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 28));
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 28);
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
 
-                EndPoint receivedFrom = new IPEndPoint(connectTo, TestPortBase + 28);
+                EndPoint receivedFrom = new IPEndPoint(connectTo, port);
                 int received = serverSocket.ReceiveFrom(new byte[1], ref receivedFrom);
 
                 Assert.Equal(1, received);
@@ -1516,7 +1524,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
-            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 29);
+            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 210);
             Assert.Throws<ArgumentException>(() => {
                 socket.BeginReceiveFrom(new byte[1], 0, 1, SocketFlags.None, ref receivedFrom, null, null);
             });
@@ -1528,8 +1536,8 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 55, AddressFamily.InterNetworkV6);
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 55));
+                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 211, AddressFamily.InterNetworkV6);
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 211));
 
                 Assert.Throws<ArgumentException>(() => {
                     socket.BeginReceiveFrom(new byte[1], 0, 1, SocketFlags.None, ref receivedFrom, null, null);
@@ -1540,40 +1548,41 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void BeginReceiveFromV4BoundToSpecificV4_Success()
         {
-            BeginReceiveFrom_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            BeginReceiveFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 212);
         }
 
         [Fact]
         public void BeginReceiveFromV4BoundToAnyV4_Success()
         {
-            BeginReceiveFrom_Helper(IPAddress.Any, IPAddress.Loopback);
+            BeginReceiveFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 213);
         }
 
         [Fact]
         public void BeginReceiveFromV6BoundToSpecificV6_Success()
         {
-            BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 214);
         }
 
         [Fact]
         public void BeginReceiveFromV6BoundToAnyV6_Success()
         {
-            BeginReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            BeginReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 215);
         }
 
         [Fact]
         public void BeginReceiveFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                BeginReceiveFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 216);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void BeginReceiveFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 217);
             });
         }
 
@@ -1581,23 +1590,23 @@ namespace System.Net.Sockets.Tests
         public void BeginReceiveFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                BeginReceiveFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 218);
             });
         }
 
         [Fact]
         public void BeginReceiveFromV4BoundToAnyV6_Success()
         {
-            BeginReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            BeginReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 219);
         }
 
-        private void BeginReceiveFrom_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void BeginReceiveFrom_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
                 serverSocket.ReceiveTimeout = 500;
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 30));
-                EndPoint receivedFrom = new IPEndPoint(connectTo, TestPortBase + 30);
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
+                EndPoint receivedFrom = new IPEndPoint(connectTo, port);
                 IAsyncResult async = serverSocket.BeginReceiveFrom(new byte[1], 0, 1, SocketFlags.None, 
                     ref receivedFrom, null, null);
 
@@ -1605,14 +1614,14 @@ namespace System.Net.Sockets.Tests
                 Assert.Equal(AddressFamily.InterNetworkV6, remoteEndPoint.AddressFamily);
                 Assert.Equal(connectTo.MapToIPv6(), remoteEndPoint.Address);
 
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 30);
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
                 bool success = async.AsyncWaitHandle.WaitOne(500);
                 if (!success)
                 {
                     throw new TimeoutException();
                 }
 
-                receivedFrom = new IPEndPoint(connectTo, TestPortBase + 30);
+                receivedFrom = new IPEndPoint(connectTo, port);
                 int received = serverSocket.EndReceiveFrom(async, ref receivedFrom);
 
                 Assert.Equal(1, received);
@@ -1634,7 +1643,7 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 31);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 220);
             args.SetBuffer(new byte[1], 0, 1);
 
             Assert.Throws<ArgumentException>(() => {
@@ -1648,9 +1657,9 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 56));
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 221));
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 56, AddressFamily.InterNetworkV6);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 221, AddressFamily.InterNetworkV6);
                 args.SetBuffer(new byte[1], 0, 1);
 
                 Assert.Throws<ArgumentException>(() => {
@@ -1662,40 +1671,41 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ReceiveFromAsyncV4BoundToSpecificV4_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 222);
         }
 
         [Fact]
         public void ReceiveFromAsyncV4BoundToAnyV4_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 223);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToSpecificV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 224);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToAnyV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 225);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 226);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 227);
             });
         }
 
@@ -1703,31 +1713,31 @@ namespace System.Net.Sockets.Tests
         public void ReceiveFromAsyncV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 228);
             });
         }
 
         [Fact]
         public void ReceiveFromAsyncV4BoundToAnyV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 229);
         }
 
-        private void ReceiveFromAsync_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void ReceiveFromAsync_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 32));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
 
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(listenOn, TestPortBase + 32);
+                args.RemoteEndPoint = new IPEndPoint(listenOn, port);
                 args.SetBuffer(new byte[1], 0, 1);
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 args.UserToken = waitHandle;
                 args.Completed += AsyncCompleted;
 
                 bool async = serverSocket.ReceiveFromAsync(args);
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 32);
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
                 if (async && !waitHandle.WaitOne(200))
                 {
                     throw new TimeoutException();
@@ -1760,7 +1770,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
-            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 33);
+            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 230);
             SocketFlags socketFlags = SocketFlags.None;
             IPPacketInformation ipPacketInformation;
 
@@ -1776,8 +1786,8 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 60, AddressFamily.InterNetworkV6);
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 60));
+                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 231, AddressFamily.InterNetworkV6);
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 231));
                 SocketFlags socketFlags = SocketFlags.None;
                 IPPacketInformation ipPacketInformation;
 
@@ -1791,52 +1801,53 @@ namespace System.Net.Sockets.Tests
         [Fact] // Base case
         public void ReceiveMessageFromV4BoundToSpecificMappedV4_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, TestPortBase + 232);
         }
 
         [Fact] // Base case
         public void ReceiveMessageFromV4BoundToAnyMappedV4_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback, TestPortBase + 233);
         }
 
         [Fact]
         public void ReceiveMessageFromV4BoundToSpecificV4_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 234);
         }
 
         [Fact]
         public void ReceiveMessageFromV4BoundToAnyV4_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 235);
         }
 
         [Fact]
         public void ReceiveMessageFromV6BoundToSpecificV6_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 236);
         }
 
         [Fact]
         public void ReceiveMessageFromV6BoundToAnyV6_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 237);
         }
 
         [Fact]
         public void ReceiveMessageFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<SocketException>(() => {
-                ReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                ReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 238);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void ReceiveMessageFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<SocketException>(() => {
-                ReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                ReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 239);
             });
         }
 
@@ -1844,24 +1855,24 @@ namespace System.Net.Sockets.Tests
         public void ReceiveMessageFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<SocketException>(() => {
-                ReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                ReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 240);
             });
         }
 
         [Fact]
         public void ReceiveMessageFromV4BoundToAnyV6_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 241);
         }
 
-        private void ReceiveMessageFrom_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void ReceiveMessageFrom_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
                 serverSocket.ReceiveTimeout = 500;
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 34));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
 
-                EndPoint receivedFrom = new IPEndPoint(connectTo, TestPortBase + 34);
+                EndPoint receivedFrom = new IPEndPoint(connectTo, port);
                 SocketFlags socketFlags = SocketFlags.None;
                 IPPacketInformation ipPacketInformation;
                 int received = 0;
@@ -1878,9 +1889,9 @@ namespace System.Net.Sockets.Tests
                     out ipPacketInformation);
                 });
                 
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 34);
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
 
-                receivedFrom = new IPEndPoint(connectTo, TestPortBase + 34);
+                receivedFrom = new IPEndPoint(connectTo, port);
                 socketFlags = SocketFlags.None;
                 received = serverSocket.ReceiveMessageFrom(new byte[1], 0, 1, ref socketFlags, ref receivedFrom,
                     out ipPacketInformation);
@@ -1911,7 +1922,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
-            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 35);
+            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 250);
             SocketFlags socketFlags = SocketFlags.None;
 
             Assert.Throws<ArgumentException>(() => {
@@ -1925,8 +1936,8 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 57, AddressFamily.InterNetworkV6);
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 57));
+                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 251, AddressFamily.InterNetworkV6);
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 251));
                 SocketFlags socketFlags = SocketFlags.None;
 
                 Assert.Throws<ArgumentException>(() => {
@@ -1938,52 +1949,53 @@ namespace System.Net.Sockets.Tests
         [Fact] // Base case
         public void BeginReceiveMessageFromV4BoundToSpecificMappedV4_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, TestPortBase + 252);
         }
 
         [Fact] // Base case
         public void BeginReceiveMessageFromV4BoundToAnyMappedV4_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback, TestPortBase + 253);
         }
 
         [Fact]
         public void BeginReceiveMessageFromV4BoundToSpecificV4_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 254);
         }
 
         [Fact]
         public void BeginReceiveMessageFromV4BoundToAnyV4_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 255);
         }
 
         [Fact]
         public void BeginReceiveMessageFromV6BoundToSpecificV6_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 256);
         }
 
         [Fact]
         public void BeginReceiveMessageFromV6BoundToAnyV6_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 257);
         }
 
         [Fact]
         public void BeginReceiveMessageFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                BeginReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 258);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                BeginReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 259);
             });
         }
 
@@ -1991,22 +2003,22 @@ namespace System.Net.Sockets.Tests
         public void BeginReceiveMessageFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                BeginReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 260);
             });
         }
 
         [Fact]
         public void BeginReceiveMessageFromV4BoundToAnyV6_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 261);
         }
 
-        private void BeginReceiveMessageFrom_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void BeginReceiveMessageFrom_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 36));
-                EndPoint receivedFrom = new IPEndPoint(connectTo, TestPortBase + 36);
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
+                EndPoint receivedFrom = new IPEndPoint(connectTo, port);
                 SocketFlags socketFlags = SocketFlags.None;
                 IPPacketInformation ipPacketInformation;
                 IAsyncResult async = serverSocket.BeginReceiveMessageFrom(new byte[1], 0, 1, socketFlags,
@@ -2015,13 +2027,13 @@ namespace System.Net.Sockets.Tests
                 Assert.Equal(AddressFamily.InterNetworkV6, remoteEndPoint.AddressFamily);
                 Assert.Equal(connectTo.MapToIPv6(), remoteEndPoint.Address);
 
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 36);
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
                 bool success = async.AsyncWaitHandle.WaitOne(500);
                 if (!success)
                 {
                     throw new TimeoutException();
                 }
-                receivedFrom = new IPEndPoint(connectTo, TestPortBase + 36);
+                receivedFrom = new IPEndPoint(connectTo, port);
                 int received = serverSocket.EndReceiveMessageFrom(async, ref socketFlags, ref receivedFrom, out ipPacketInformation);
 
                 Assert.Equal(1, received);
@@ -2050,7 +2062,7 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 37);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 270);
             args.SetBuffer(new byte[1], 0, 1);
 
             Assert.Throws<ArgumentException>(() => {
@@ -2064,9 +2076,9 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 58));
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 271));
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 58, AddressFamily.InterNetworkV6);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 271, AddressFamily.InterNetworkV6);
                 args.SetBuffer(new byte[1], 0, 1);
 
                 Assert.Throws<ArgumentException>(() => {
@@ -2078,52 +2090,53 @@ namespace System.Net.Sockets.Tests
         [Fact] // Base case
         public void ReceiveMessageFromAsyncV4BoundToSpecificMappedV4_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, TestPortBase + 272);
         }
 
         [Fact] // Base case
         public void ReceiveMessageFromAsyncV4BoundToAnyMappedV4_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback, TestPortBase + 273);
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV4BoundToSpecificV4_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 274);
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV4BoundToAnyV4_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.Any, IPAddress.Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 275);
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV6BoundToSpecificV6_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 276);
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV6BoundToAnyV6_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 277);
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>( () => { 
-                ReceiveMessageFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                ReceiveMessageFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 278);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveMessageFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                ReceiveMessageFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 279);
             });
         }
 
@@ -2131,25 +2144,25 @@ namespace System.Net.Sockets.Tests
         public void ReceiveMessageFromAsyncV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveMessageFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                ReceiveMessageFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 280);
             });
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV4BoundToAnyV6_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 281);
         }
 
-        private void ReceiveMessageFromAsync_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void ReceiveMessageFromAsync_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
                 serverSocket.ReceiveTimeout = 500;
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 38));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
 
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(connectTo, TestPortBase + 38);
+                args.RemoteEndPoint = new IPEndPoint(connectTo, port);
                 args.SetBuffer(new byte[1], 0, 1);
                 args.Completed += AsyncCompleted;
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
@@ -2157,7 +2170,7 @@ namespace System.Net.Sockets.Tests
                 bool async = serverSocket.ReceiveMessageFromAsync(args);
                 Assert.True(async);
 
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 38);
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
 
                 if (!waitHandle.WaitOne(500))
                 {

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsAsync.cs
@@ -51,6 +51,7 @@ namespace System.Net.Sockets.Tests
         #region Basic Arguments
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Disposed_Throw()
         {
             using (SocketTestServer.SocketTestServerFactory(Server))
@@ -68,6 +69,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullArgs_Throw()
         {
             using (SocketTestServer.SocketTestServerFactory(Server))
@@ -85,6 +87,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NotConnected_Throw()
         {
             Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
@@ -97,6 +100,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullList_Throws()
         {
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => {
@@ -107,18 +111,21 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullElement_Ignored()
         {
             SendPackets((SendPacketsElement)null, 0);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void EmptyList_Ignored()
         {
             SendPackets(new SendPacketsElement[0], SocketError.Success, 0);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SocketAsyncEventArgs_DefaultSendSize_0()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
@@ -130,30 +137,35 @@ namespace System.Net.Sockets.Tests
         #region Buffers
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NormalBuffer_Success()
         {
             SendPackets(new SendPacketsElement(new byte[10]), 10);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NormalBufferRange_Success()
         {
             SendPackets(new SendPacketsElement(new byte[10], 5, 5), 5);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void EmptyBuffer_Ignored()
         {
             SendPackets(new SendPacketsElement(new byte[0]), 0);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferZeroCount_Ignored()
         {
             SendPackets(new SendPacketsElement(new byte[10], 4, 0), 0);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferMixedBuffers_ZeroCountBufferIgnored()
         {
             SendPacketsElement[] elements = new SendPacketsElement[] 
@@ -166,6 +178,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferZeroCountThenNormal_ZeroCountIgnored()
         {
             Assert.True(Capability.IPv6Support());
@@ -218,6 +231,7 @@ namespace System.Net.Sockets.Tests
         #region Files
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_EmptyFileName_Throws()
         {
             Assert.Throws<ArgumentException>(() => {
@@ -226,6 +240,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_BlankFileName_Throws()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -236,6 +251,7 @@ namespace System.Net.Sockets.Tests
         }
         
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_BadCharactersFileName_Throws()
         {
             Assert.Throws<ArgumentException>(() => {
@@ -245,6 +261,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_MissingDirectoryName_Throws()
         {
             Assert.Throws<DirectoryNotFoundException>(() => {
@@ -254,6 +271,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_MissingFile_Throws()
         {
             Assert.Throws<FileNotFoundException>(() => {
@@ -263,24 +281,28 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_File_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName), TestFileSize); // Whole File
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_FileZeroCount_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName, 0, 0), TestFileSize);  // Whole File
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_FilePart_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName, 10, 20), 20);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_FileMultiPart_Success()
         {
             SendPacketsElement[] elements = new SendPacketsElement[] 
@@ -293,6 +315,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_FileLargeOffset_Throws()
         {
             // Length is validated on Send
@@ -300,6 +323,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_FileLargeCount_Throws()
         {
             // Length is validated on Send
@@ -312,6 +336,7 @@ namespace System.Net.Sockets.Tests
         // This test assumes sequential execution of tests and that it is going to be executed after other tests
         // that used Sockets. 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void TestFinalizers()
         {
             // Making several passes through the FReachable list.

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsElementTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsElementTest.cs
@@ -7,6 +7,7 @@ namespace System.Net.Sockets.Tests
         #region Buffer
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullBufferCtor_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -15,6 +16,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullBufferCtorWithOffset_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -23,6 +25,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullBufferCtorWithEndOfPacket_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -32,6 +35,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void EmptyBufferCtor_Success()
         {
             // Elements with empty Buffers are ignored on Send
@@ -45,6 +49,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorNormal_Success()
         {
             SendPacketsElement element = new SendPacketsElement(new byte[10]);
@@ -57,6 +62,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorNegOffset_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -65,6 +71,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorNegCount_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -73,6 +80,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorLargeOffset_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -81,6 +89,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorLargeCount_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -89,6 +98,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorEndOfBufferTrue_Success()
         {
             SendPacketsElement element = new SendPacketsElement(new byte[10], 2, 8, true);
@@ -101,6 +111,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorEndOfBufferFalse_Success()
         {
             SendPacketsElement element = new SendPacketsElement(new byte[10], 6, 4, false);
@@ -113,6 +124,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorZeroCount_Success()
         {
             // Elements with empty Buffers are ignored on Send
@@ -130,6 +142,7 @@ namespace System.Net.Sockets.Tests
         #region File
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNull_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -138,6 +151,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorEmpty_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -150,6 +164,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorWhiteSpace_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -162,6 +177,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNormal_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -174,6 +190,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorZeroCountLength_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -186,6 +203,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNegOffset_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -194,6 +212,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNegCount_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -204,6 +223,7 @@ namespace System.Net.Sockets.Tests
         // File lengths are validated on send
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorEndOfBufferTrue_Success()
         {
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 2, 8, true);
@@ -215,6 +235,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorEndOfBufferFalse_Success()
         {
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 6, 4, false);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.APMServer.Tests.csproj
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.APMServer.Tests.csproj
@@ -6,11 +6,12 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{DA4FB750-6D71-495F-B6B9-3029E58F3AC3}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>Linux;OSX;FreeBSD</UnsupportedPlatforms>
+    <UnsupportedPlatforms>OSX;FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+
   <ItemGroup>
     <Compile Include="AcceptAsync.cs" />
     <Compile Include="AgnosticListenerTest.cs" />
@@ -27,6 +28,7 @@
     <Compile Include="SendPacketsElementTest.cs" />
     <Compile Include="TimeoutTest.cs" />
     <Compile Include="UdpClientTest.cs" />
+
     <!-- Common Sockets files -->
     <Compile Include="$(CommonTestPath)\System.Net\Sockets\SocketTestServer.DefaultAPMFactoryConfiguration.cs">
       <Link>SocketCommon\SocketTestServer.DefaultAsyncFactoryConfiguration.cs</Link>
@@ -43,6 +45,7 @@
     <Compile Include="$(CommonTestPath)\System.Net\Sockets\SocketImplementationType.cs">
       <Link>SocketCommon\SocketImplementationType.cs</Link>
     </Compile>
+
     <!-- Common test files -->
     <Compile Include="$(CommonTestPath)\System.Net\TestLogging.cs">
       <Link>Common\System.Net\TestLogging.cs</Link>
@@ -57,6 +60,7 @@
       <Link>Common\System.Net\Capability.Sockets.cs</Link>
     </Compile>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\System.Net.NameResolution\src\System.Net.NameResolution.csproj">
       <Project>{1714448C-211E-48C1-8B7E-4EE667D336A1}</Project>
@@ -67,6 +71,7 @@
       <Name>System.Net.Sockets</Name>
     </ProjectReference>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.AsyncServer.Tests.csproj
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.AsyncServer.Tests.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{99794DE7-AC2B-400B-B388-511718375437}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>Linux;OSX;FreeBSD</UnsupportedPlatforms>
+    <UnsupportedPlatforms>OSX;FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/TimeoutTest.cs
@@ -6,8 +6,6 @@ namespace System.Net.Sockets.Tests
     {
         private const int TestPortBase = 8110;
 
-        private const int ServerPort = TestPortBase;
-
         [Fact]
         public void GetAndSet_Success()
         {
@@ -33,11 +31,11 @@ namespace System.Net.Sockets.Tests
             {
                 using (Socket remoteSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    localSocket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, ServerPort));
+                    localSocket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase));
                     localSocket.Listen(1);
                     IAsyncResult localAsync = localSocket.BeginAccept(null, null);
 
-                    remoteSocket.Connect(IPAddress.IPv6Loopback, ServerPort);
+                    remoteSocket.Connect(IPAddress.IPv6Loopback, TestPortBase);
 
                     Socket acceptedSocket = localSocket.EndAccept(localAsync);
                     acceptedSocket.ReceiveTimeout = 100;
@@ -59,11 +57,11 @@ namespace System.Net.Sockets.Tests
             {
                 using (Socket remoteSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    localSocket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, ServerPort));
+                    localSocket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 1));
                     localSocket.Listen(1);
                     IAsyncResult localAsync = localSocket.BeginAccept(null, null);
 
-                    remoteSocket.Connect(IPAddress.IPv6Loopback, ServerPort);
+                    remoteSocket.Connect(IPAddress.IPv6Loopback, TestPortBase + 1);
 
                     Socket acceptedSocket = localSocket.EndAccept(localAsync);
                     acceptedSocket.SendTimeout = 100;

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/UdpClientTest.cs
@@ -9,7 +9,7 @@ namespace NCLTest.Sockets
 {
     public class UDPClientTest
     {
-        private const int TestPortBase = 8400;
+        private const int TestPortBase = 8600;
         private ManualResetEvent _waitHandle = new ManualResetEvent(false);
 
         [Fact]

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/project.json
@@ -10,10 +10,7 @@
     "System.IO": "4.0.10-beta-*",
     "System.Net.Primitives": "4.0.10-beta-*",
     
-    "xunit": "2.0.0-beta5-build2785",
-    "xunit.abstractions.netcore": "1.0.0-prerelease",
-    "xunit.assert": "2.0.0-beta5-build2785",
-    "xunit.core.netcore": "1.0.1-prerelease",
+    "xunit": "2.1.0-beta3-*",
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -344,6 +344,7 @@
 
   <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
     <Compile Include="System\Net\Sockets\SocketAsyncEngineBackend.Linux.cs" />
+    <Compile Include="System\Net\Sockets\SocketPal.Linux.cs" />
 
     <Compile Include="$(CommonPath)\Interop\Linux\Interop.Libraries.cs">
       <Link>Interop\Linux\Interop.Libraries.cs</Link>
@@ -406,6 +407,7 @@
 
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
     <Compile Include="System\Net\Sockets\SocketAsyncEngineBackend.OSX.cs" />
+    <Compile Include="System\Net\Sockets\SocketPal.OSX.cs" />
 
     <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
       <Link>Interop\OSX\Interop.Libraries.cs</Link>

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -300,6 +300,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.listen.cs">
       <Link>Interop\Unix\libc\Interop.listen.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.poll.cs">
+      <Link>Interop\Unix\libc\Interop.poll.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.recv.cs">
       <Link>Interop\Unix\libc\Interop.recv.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -114,10 +114,10 @@ namespace System.Net.Sockets
             _socketType = socketType;
             _protocolType = protocolType;
 
-//            if (addressFamily == AddressFamily.InterNetworkV6)
-//            {
-//                DualMode = false;
-//            }
+            if (addressFamily == AddressFamily.InterNetworkV6)
+            {
+                DualMode = false;
+            }
 
             if (s_LoggingEnabled) Logging.Exit(Logging.Sockets, this, "Socket", null);
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -114,10 +114,7 @@ namespace System.Net.Sockets
             _socketType = socketType;
             _protocolType = protocolType;
 
-            if (addressFamily == AddressFamily.InterNetworkV6)
-            {
-                DualMode = false;
-            }
+            Debug.Assert(addressFamily != AddressFamily.InterNetworkV6 || !DualMode);
 
             if (s_LoggingEnabled) Logging.Exit(Logging.Sockets, this, "Socket", null);
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -114,10 +114,10 @@ namespace System.Net.Sockets
             _socketType = socketType;
             _protocolType = protocolType;
 
-            if (addressFamily == AddressFamily.InterNetworkV6)
-            {
-                DualMode = false;
-            }
+//            if (addressFamily == AddressFamily.InterNetworkV6)
+//            {
+//                DualMode = false;
+//            }
 
             if (s_LoggingEnabled) Logging.Exit(Logging.Sockets, this, "Socket", null);
         }
@@ -5466,7 +5466,7 @@ namespace System.Net.Sockets
                 //
                 // update our internal state after this socket error and throw
                 //
-                SocketException socketException = SocketExceptionFactory.CreateSocketException(endPointSnapshot);
+                SocketException socketException = SocketExceptionFactory.CreateSocketException((int)errorCode, endPointSnapshot);
                 UpdateStatusAfterSocketError(socketException);
                 if (s_LoggingEnabled) Logging.Exception(Logging.Sockets, this, "Connect", socketException);
                 throw socketException;
@@ -6352,6 +6352,7 @@ namespace System.Net.Sockets
             socket._protocolType = _protocolType;
             socket.m_RightEndPoint = m_RightEndPoint;
             socket.m_RemoteEndPoint = remoteEP;
+
             //
             // the socket is connected
             //

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -114,6 +114,11 @@ namespace System.Net.Sockets
             _socketType = socketType;
             _protocolType = protocolType;
 
+            if (addressFamily == AddressFamily.InterNetworkV6)
+            {
+                DualMode = false;
+            }
+
             if (s_LoggingEnabled) Logging.Exit(Logging.Sockets, this, "Socket", null);
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2210,35 +2210,33 @@ namespace System.Net.Sockets
             {
                 return getIPv6MulticastOpt(optionName);
             }
-            else
+
+            int optionValue = 0;
+
+            // This can throw ObjectDisposedException.
+            SocketError errorCode = SocketPal.GetSockOpt(
+                _handle,
+                optionLevel,
+                optionName,
+                out optionValue);
+
+            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+
+            //
+            // if the native call fails we'll throw a SocketException
+            //
+            if (errorCode != SocketError.Success)
             {
-                int optionValue = 0;
-
-                // This can throw ObjectDisposedException.
-                SocketError errorCode = SocketPal.GetSockOpt(
-                    _handle,
-                    optionLevel,
-                    optionName,
-                    out optionValue);
-
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
-
                 //
-                // if the native call fails we'll throw a SocketException
+                // update our internal state after this socket error and throw
                 //
-                if (errorCode != SocketError.Success)
-                {
-                    //
-                    // update our internal state after this socket error and throw
-                    //
-                    SocketException socketException = new SocketException((int)errorCode);
-                    UpdateStatusAfterSocketError(socketException);
-                    if (s_LoggingEnabled) Logging.Exception(Logging.Sockets, this, "GetSocketOption", socketException);
-                    throw socketException;
-                }
-
-                return optionValue;
+                SocketException socketException = new SocketException((int)errorCode);
+                UpdateStatusAfterSocketError(socketException);
+                if (s_LoggingEnabled) Logging.Exception(Logging.Sockets, this, "GetSocketOption", socketException);
+                throw socketException;
             }
+
+            return optionValue;
         }
 
         /// <devdoc>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1280,8 +1280,6 @@ namespace System.Net.Sockets
             //make sure we don't let the app mess up the buffer array enough to cause
             //corruption.
 
-            errorCode = SocketError.Success;
-
             int bytesTransferred;
             errorCode = SocketPal.Send(_handle, buffers, socketFlags, out bytesTransferred);
 
@@ -1368,17 +1366,17 @@ namespace System.Net.Sockets
             GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Send() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " size:" + size);
 
             // This can throw ObjectDisposedException.
-            int bytesTransferred = SocketPal.Send(_handle, buffer, offset, size, socketFlags);
+            int bytesTransferred;
+            errorCode = SocketPal.Send(_handle, buffer, offset, size, socketFlags, out bytesTransferred);
 
             //
             // if the native call fails we'll throw a SocketException
             //
-            if ((SocketError)bytesTransferred == SocketError.SocketError)
+            if (errorCode != SocketError.Success)
             {
                 //
                 // update our internal state after this socket error and throw
                 //
-                errorCode = SocketPal.GetLastSocketError();
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_LoggingEnabled)
                 {
@@ -1448,17 +1446,18 @@ namespace System.Net.Sockets
             Internals.SocketAddress socketAddress = CheckCacheRemote(ref endPointSnapshot, false);
 
             // This can throw ObjectDisposedException.
-            int bytesTransferred = SocketPal.SendTo(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, socketAddress.Size);
+            int bytesTransferred;
+            SocketError errorCode = SocketPal.SendTo(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, socketAddress.Size, out bytesTransferred);
 
             //
             // if the native call fails we'll throw a SocketException
             //
-            if ((SocketError)bytesTransferred == SocketError.SocketError)
+            if (errorCode != SocketError.Success)
             {
                 //
                 // update our internal state after this socket error and throw
                 //
-                SocketException socketException = new SocketException((int)SocketPal.GetLastSocketError());
+                SocketException socketException = new SocketException((int)errorCode);
                 UpdateStatusAfterSocketError(socketException);
                 if (s_LoggingEnabled) Logging.Exception(Logging.Sockets, this, "SendTo", socketException);
                 throw socketException;
@@ -1584,17 +1583,14 @@ namespace System.Net.Sockets
             ValidateBlockingMode();
             GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Receive() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " size:" + size);
 
-            // This can throw ObjectDisposedException.
-            errorCode = SocketError.Success;
+            int bytesTransferred;
+            errorCode = SocketPal.Receive(_handle, buffer, offset, size, socketFlags, out bytesTransferred);
 
-            int bytesTransferred = SocketPal.Receive(_handle, buffer, offset, size, socketFlags);
-
-            if ((SocketError)bytesTransferred == SocketError.SocketError)
+            if (errorCode != SocketError.Success)
             {
                 //
                 // update our internal state after this socket error and throw
                 //
-                errorCode = SocketPal.GetLastSocketError();
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_LoggingEnabled)
                 {
@@ -1879,14 +1875,15 @@ namespace System.Net.Sockets
             Internals.SocketAddress socketAddressOriginal = IPEndPointExtensions.Serialize(endPointSnapshot);
 
             // This can throw ObjectDisposedException.
-            int bytesTransferred = SocketPal.ReceiveFrom(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, ref socketAddress.InternalSize);
+            int bytesTransferred;
+            SocketError errorCode = SocketPal.ReceiveFrom(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, ref socketAddress.InternalSize, out bytesTransferred);
 
             // If the native call fails we'll throw a SocketException.
             // Must do this immediately after the native call so that the SocketException() constructor can pick up the error code.
             SocketException socketException = null;
-            if ((SocketError)bytesTransferred == SocketError.SocketError)
+            if (errorCode != SocketError.Success)
             {
-                socketException = new SocketException((int)SocketPal.GetLastSocketError());
+                socketException = new SocketException((int)errorCode);
                 UpdateStatusAfterSocketError(socketException);
                 if (s_LoggingEnabled) Logging.Exception(Logging.Sockets, this, "ReceiveFrom", socketException);
 
@@ -5581,7 +5578,8 @@ namespace System.Net.Sockets
                         }
                         else
                         {
-                            errorCode = (SocketError)SocketPal.Receive(_handle, null, 0, 0, SocketFlags.None);
+                            int unused;
+                            errorCode = SocketPal.Receive(_handle, null, 0, 0, SocketFlags.None, out unused);
                             GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") recv():" + errorCode.ToString());
 
                             if (errorCode != (SocketError)0)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -392,28 +392,37 @@ namespace System.Net.Sockets
                 // TODO: assert that queues are all empty if _registeredEvents was SocketAsyncEvents.None?
             }
 
-            while (!acceptOrConnectQueue.IsEmpty)
+            if (!acceptOrConnectQueue.IsStopped)
             {
-                AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor);
-                Debug.Assert(completed);
-                acceptOrConnectQueue.Dequeue();
+                while (!acceptOrConnectQueue.IsEmpty)
+                {
+                    AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
+                    bool completed = op.TryCompleteAsync(_fileDescriptor);
+                    Debug.Assert(completed);
+                    acceptOrConnectQueue.Dequeue();
+                }
             }
 
-            while (!sendQueue.IsEmpty)
+            if (!sendQueue.IsStopped)
             {
-                SendReceiveOperation op = sendQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor);
-                Debug.Assert(completed);
-                sendQueue.Dequeue();
+                while (!sendQueue.IsEmpty)
+                {
+                    SendReceiveOperation op = sendQueue.Head;
+                    bool completed = op.TryCompleteAsync(_fileDescriptor);
+                    Debug.Assert(completed);
+                    sendQueue.Dequeue();
+                }
             }
 
-            while (!receiveQueue.IsEmpty)
+            if (!receiveQueue.IsStopped)
             {
-                TransferOperation op = receiveQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor);
-                Debug.Assert(completed);
-                receiveQueue.Dequeue();
+                while (!receiveQueue.IsEmpty)
+                {
+                    TransferOperation op = receiveQueue.Head;
+                    bool completed = op.TryCompleteAsync(_fileDescriptor);
+                    Debug.Assert(completed);
+                    receiveQueue.Dequeue();
+                }
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -767,7 +767,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _receiveQueue, operation, SocketAsyncEvents.Write, out isStopped))
+            while (!TryBeginOperation(ref _receiveQueue, operation, SocketAsyncEvents.Read, out isStopped))
             {
                 if (isStopped)
                 {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -345,12 +345,8 @@ namespace System.Net.Sockets
             SocketAsyncEvents events = _registeredEvents & ~SocketAsyncEvents.Read;
 
             Interop.Error errorCode;
-            if (!_engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode))
-            {
-                // TODO: throw an appropiate exception
-                throw new Exception(string.Format("UnregisterRead: {0}", errorCode));
-            }
-
+            bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode);
+            Debug.Assert(unregistered, string.Format("UnregisterRead failed: {0}", errorCode));
             _registeredEvents = events;
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -371,15 +371,14 @@ namespace System.Net.Sockets
             }
         }
 
-        public void Close()
+        private void ProcessClose()
         {
-            Debug.Assert(!Monitor.IsEntered(_queueLock));
+            Debug.Assert(Monitor.IsEntered(_closeLock) && !Monitor.IsEntered(_queueLock));
 
             OperationQueue<AcceptOrConnectOperation> acceptOrConnectQueue;
             OperationQueue<SendOperation> sendQueue;
             OperationQueue<TransferOperation> receiveQueue;
 
-            lock (_closeLock)
             lock (_queueLock)
             {
                 // Drain queues and unregister events
@@ -415,6 +414,16 @@ namespace System.Net.Sockets
                 bool completed = op.TryCompleteAsync(_fileDescriptor);
                 Debug.Assert(completed);
                 receiveQueue.Dequeue();
+            }
+        }
+
+        public void Close()
+        {
+            Debug.Assert(!Monitor.IsEntered(_queueLock));
+
+            lock (_closeLock)
+            {
+                ProcessClose();
             }
         }
 
@@ -1215,9 +1224,16 @@ namespace System.Net.Sockets
 
                 if ((events & SocketAsyncEvents.Error) != 0)
                 {
-                    // We should only receive error events in conjuntction with other events.
-                    // Processing for those events will pick up the error.
-                    Debug.Assert((events & ~SocketAsyncEvents.Error) != 0);
+                    // Set the Read and Write flags as well; the processing for these events
+                    // will pick up the error.
+                    events |= SocketAsyncEvents.Read | SocketAsyncEvents.Write;
+                }
+
+                if ((events & SocketAsyncEvents.Close) != 0)
+                {
+                    // Drain queues and unregister this fd, then return.
+                    ProcessClose();
+                    return;
                 }
 
                 if ((events & SocketAsyncEvents.ReadClose) != 0)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -95,6 +95,7 @@ namespace System.Net.Sockets
                     return true;
                 }
 
+                var spinWait = new SpinWait();
                 for (;;)
                 {
                     int state = Interlocked.CompareExchange(ref _state, (int)State.Cancelled, (int)State.Waiting);
@@ -102,6 +103,7 @@ namespace System.Net.Sockets
                     {
                         case State.Running:
                             // A completion attempt is in progress. Keep busy-waiting.
+                            spinWait.SpinOnce();
                             break;
 
                         case State.Complete:

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -20,17 +20,104 @@ namespace System.Net.Sockets
     {
         private abstract class AsyncOperation
         {
+            private enum State
+            {
+                Waiting = 0,
+                Running = 1,
+                Complete = 2,
+                Cancelled = 3
+            }
+
+            private int _state; // Actually AsyncOperation.State
+
             public AsyncOperation Next;
+            protected object CallbackOrEvent;
             public SocketError ErrorCode;
             public byte[] SocketAddress;
             public int SocketAddressLen;
 
+            public ManualResetEventSlim Event { set { CallbackOrEvent = value; } }
+
             public AsyncOperation()
             {
+                _state = (int)State.Waiting;
                 Next = this;
             }
 
-            public abstract void Complete();
+            public void QueueCompletionCallback()
+            {
+                Debug.Assert(!(CallbackOrEvent is ManualResetEventSlim));
+                Debug.Assert(_state != (int)State.Cancelled);
+
+                ThreadPool.QueueUserWorkItem(o => ((AsyncOperation)o).DoCallback(), this);
+            }
+
+            public bool TryComplete(int fileDescriptor)
+            {
+                Debug.Assert(_state == (int)State.Waiting);
+
+                return DoTryComplete(fileDescriptor);
+            }
+
+            public bool TryCompleteAsync(int fileDescriptor)
+            {
+                int state = Interlocked.CompareExchange(ref _state, (int)State.Running, (int)State.Waiting);
+                if (state == (int)State.Cancelled)
+                {
+                    // This operation has been cancelled.
+                    return true;
+                }
+                Debug.Assert(state != (int)State.Complete && state != (int)State.Running);
+
+                if (DoTryComplete(fileDescriptor))
+                {
+                    var @event = CallbackOrEvent as ManualResetEventSlim;
+                    if (@event != null)
+                    {
+                        @event.Set();
+                    }
+                    else
+                    {
+                        QueueCompletionCallback();
+                    }
+                    Volatile.Write(ref _state, (int)State.Complete);
+                    return true;
+                }
+
+                Volatile.Write(ref _state, (int)State.Waiting);
+                return false;
+            }
+
+            public bool Wait(int timeout)
+            {
+                if (((ManualResetEventSlim)CallbackOrEvent).Wait(timeout))
+                {
+                    return true;
+                }
+
+                for (;;)
+                {
+                    int state = Interlocked.CompareExchange(ref _state, (int)State.Cancelled, (int)State.Waiting);
+                    switch ((State)state)
+                    {
+                        case State.Running:
+                            // A completion attempt is in progress. Keep busy-waiting.
+                            break;
+
+                        case State.Complete:
+                            // A completion attempt succeeded. Consider this operation as having completed within the timeout.
+                            return true;
+
+                        case State.Waiting:
+                            // This operation was successfully cancelled.
+                            return false;
+                    }
+                }
+            }
+
+            protected abstract bool DoTryComplete(int fileDescriptor);
+
+            protected abstract void DoCallback();
         }
 
         private abstract class TransferOperation : AsyncOperation
@@ -43,32 +130,51 @@ namespace System.Net.Sockets
             public int ReceivedFlags;
         }
 
-        private sealed class SendReceiveOperation : TransferOperation
+        private abstract class SendReceiveOperation : TransferOperation
         {
-            public Action<int, byte[], int, int, SocketError> Callback;
+            public Action<int, byte[], int, int, SocketError> Callback { set { CallbackOrEvent = value; } }
             public BufferList Buffers;
             public int BufferIndex;
 
-            public override void Complete()
+            protected sealed override void DoCallback()
             {
-                Debug.Assert(Callback != null);
+                var callback = (Action<int, byte[], int, int, SocketError>)CallbackOrEvent;
+                callback(BytesTransferred, SocketAddress, SocketAddressLen, ReceivedFlags, ErrorCode);
+            }
+        }
 
-                Callback(BytesTransferred, SocketAddress, SocketAddressLen, ReceivedFlags, ErrorCode);
+        private sealed class SendOperation : SendReceiveOperation
+        {
+            protected override bool DoTryComplete(int fileDescriptor)
+            {
+                return SocketPal.TryCompleteSendTo(fileDescriptor, Buffer, Buffers, ref BufferIndex, ref Offset, ref Count, Flags, SocketAddress, SocketAddressLen, ref BytesTransferred, out ErrorCode);
+            }
+        }
+
+        private sealed class ReceiveOperation : SendReceiveOperation
+        {
+            protected override bool DoTryComplete(int fileDescriptor)
+            {
+                return SocketPal.TryCompleteReceiveFrom(fileDescriptor, Buffer, Buffers, Offset, Count, Flags, SocketAddress, ref SocketAddressLen, out BytesTransferred, out ReceivedFlags, out ErrorCode);
             }
         }
 
         private sealed class ReceiveMessageFromOperation : TransferOperation
         {
-            public Action<int, byte[], int, int, IPPacketInformation, SocketError> Callback;
+            public Action<int, byte[], int, int, IPPacketInformation, SocketError> Callback { set { CallbackOrEvent = value; } }
             public bool IsIPv4;
             public bool IsIPv6;
             public IPPacketInformation IPPacketInformation;
 
-            public override void Complete()
+            protected override bool DoTryComplete(int fileDescriptor)
             {
-                Debug.Assert(Callback != null);
+                return SocketPal.TryCompleteReceiveMessageFrom(fileDescriptor, Buffer, Offset, Count, Flags, SocketAddress, ref SocketAddressLen, IsIPv4, IsIPv6, out BytesTransferred, out ReceivedFlags, out IPPacketInformation, out ErrorCode);
+            }
 
-                Callback(BytesTransferred, SocketAddress, SocketAddressLen, ReceivedFlags, IPPacketInformation, ErrorCode);
+            protected override void DoCallback()
+            {
+                var callback = (Action<int, byte[], int, int, IPPacketInformation, SocketError>)CallbackOrEvent;
+                callback(BytesTransferred, SocketAddress, SocketAddressLen, ReceivedFlags, IPPacketInformation, ErrorCode);
             }
         }
 
@@ -78,34 +184,50 @@ namespace System.Net.Sockets
 
         private sealed class AcceptOperation : AcceptOrConnectOperation
         {
-            public Action<int, byte[], int, SocketError> Callback;
+            public Action<int, byte[], int, SocketError> Callback { set { CallbackOrEvent = value; } }
             public int AcceptedFileDescriptor;
 
-            public override void Complete()
+            protected override bool DoTryComplete(int fileDescriptor)
             {
-                Debug.Assert(Callback != null);
+                return SocketPal.TryCompleteAccept(fileDescriptor, SocketAddress, ref SocketAddressLen, out AcceptedFileDescriptor, out ErrorCode);
+            }
 
-                Callback(AcceptedFileDescriptor, SocketAddress, SocketAddressLen, ErrorCode);
+            protected override void DoCallback()
+            {
+                var callback = (Action<int, byte[], int, SocketError>)CallbackOrEvent;
+                callback(AcceptedFileDescriptor, SocketAddress, SocketAddressLen, ErrorCode);
             }
         }
 
         private sealed class ConnectOperation : AcceptOrConnectOperation
         {
-            public Action<SocketError> Callback;
+            public Action<SocketError> Callback { set { CallbackOrEvent = value; } }
 
-            public override void Complete()
+            protected override bool DoTryComplete(int fileDescriptor)
             {
-                Debug.Assert(Callback != null);
+                return SocketPal.TryCompleteConnect(fileDescriptor, SocketAddressLen, out ErrorCode);
 
-                Callback(ErrorCode);
+                // The only situation in which we should see EISCONN when completing an
+                // async connect is if this earlier connect completed successfully:
+                // POSIX does not allow more than one outstanding async connect.
+                // if (op.ErrorCode == SocketError.IsConnected)
+                // {
+                //     op.ErrorCode = SocketError.Success;
+                // }
+            }
+
+            protected override void DoCallback()
+            {
+                var callback = (Action<SocketError>)CallbackOrEvent;
+                callback(ErrorCode);
             }
         }
 
-        private enum State
+        private enum QueueState
         {
-            Stopped = -1,
             Clear = 0,
             Set = 1,
+            Stopped = 2,
         }
 
         private struct OperationQueue<TOperation>
@@ -113,8 +235,8 @@ namespace System.Net.Sockets
         {
             private AsyncOperation _tail;
 
-            public State State { get; set; }
-            public bool IsStopped { get { return State == State.Stopped; } }
+            public QueueState State { get; set; }
+            public bool IsStopped { get { return State == QueueState.Stopped; } }
             public bool IsEmpty { get { return _tail == null; } }
 
             public TOperation Head
@@ -169,7 +291,7 @@ namespace System.Net.Sockets
             {
                 OperationQueue<TOperation> result = this;
                 _tail = null;
-                State = State.Stopped;
+                State = QueueState.Stopped;
                 return result;
             }
         }
@@ -177,7 +299,7 @@ namespace System.Net.Sockets
         private int _fileDescriptor;
         private GCHandle _handle;
         private OperationQueue<TransferOperation> _receiveQueue;
-        private OperationQueue<SendReceiveOperation> _sendQueue;
+        private OperationQueue<SendOperation> _sendQueue;
         private OperationQueue<AcceptOrConnectOperation> _acceptOrConnectQueue;
         private SocketAsyncEngine _engine;
         private SocketAsyncEvents _registeredEvents;
@@ -246,66 +368,58 @@ namespace System.Net.Sockets
             bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, SocketAsyncEvents.None, _handle, out errorCode);
             _registeredEvents = (SocketAsyncEvents)(-1);
 
-			if (unregistered || errorCode == Interop.Error.EBADF)
-			{
-				_registeredEvents = SocketAsyncEvents.None;
-				_handle.Free();
-			}
+            if (unregistered || errorCode == Interop.Error.EBADF)
+            {
+                _registeredEvents = SocketAsyncEvents.None;
+                _handle.Free();
+            }
         }
 
         public void Close()
         {
             Debug.Assert(!Monitor.IsEntered(_queueLock));
 
-			OperationQueue<AcceptOrConnectOperation> acceptOrConnectQueue;
-			OperationQueue<SendReceiveOperation> sendQueue;
-			OperationQueue<TransferOperation> receiveQueue;
+            OperationQueue<AcceptOrConnectOperation> acceptOrConnectQueue;
+            OperationQueue<SendOperation> sendQueue;
+            OperationQueue<TransferOperation> receiveQueue;
 
             lock (_closeLock)
-			lock (_queueLock)
-			{
-				// Drain queues and unregister events
+            lock (_queueLock)
+            {
+                // Drain queues and unregister events
 
-				acceptOrConnectQueue = _acceptOrConnectQueue.Stop();
-				sendQueue = _sendQueue.Stop();
-				receiveQueue = _receiveQueue.Stop();
+                acceptOrConnectQueue = _acceptOrConnectQueue.Stop();
+                sendQueue = _sendQueue.Stop();
+                receiveQueue = _receiveQueue.Stop();
 
-				Unregister();
+                Unregister();
 
-				// TODO: assert that queues are all empty if _registeredEvents was SocketAsyncEvents.None?
-			}
+                // TODO: assert that queues are all empty if _registeredEvents was SocketAsyncEvents.None?
+            }
 
-			while (!acceptOrConnectQueue.IsEmpty)
-			{
-				AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
+            while (!acceptOrConnectQueue.IsEmpty)
+            {
+                AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
+                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                Debug.Assert(completed);
+                acceptOrConnectQueue.Dequeue();
+            }
 
-				var acceptOp = op as AcceptOperation;
-				bool completed = acceptOp != null ?
-					TryCompleteAccept(_fileDescriptor, acceptOp) :
-					TryCompleteConnect(_fileDescriptor, (ConnectOperation)op);
+            while (!sendQueue.IsEmpty)
+            {
+                SendReceiveOperation op = sendQueue.Head;
+                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                Debug.Assert(completed);
+                sendQueue.Dequeue();
+            }
 
-				Debug.Assert(completed);
-				acceptOrConnectQueue.Dequeue();
-				QueueCompletion(op);
-			}
-
-			while (!sendQueue.IsEmpty)
-			{
-				SendReceiveOperation op = sendQueue.Head;
-				bool completed = TryCompleteSendTo(_fileDescriptor, op);
-				Debug.Assert(completed);
-				sendQueue.Dequeue();
-				QueueCompletion(op);
-			}
-
-			while (!receiveQueue.IsEmpty)
-			{
-				TransferOperation op = receiveQueue.Head;
-				bool completed = TryCompleteReceive(_fileDescriptor, op);
-				Debug.Assert(completed);
-				receiveQueue.Dequeue();
-				QueueCompletion(op);
-			}
+            while (!receiveQueue.IsEmpty)
+            {
+                TransferOperation op = receiveQueue.Head;
+                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                Debug.Assert(completed);
+                receiveQueue.Dequeue();
+            }
         }
 
         private bool TryBeginOperation<TOperation>(ref OperationQueue<TOperation> queue, TOperation operation, out bool isStopped)
@@ -315,16 +429,16 @@ namespace System.Net.Sockets
             {
                 switch (queue.State)
                 {
-                    case State.Stopped:
+                    case QueueState.Stopped:
                         isStopped = true;
                         return false;
 
-                    case State.Clear:
+                    case QueueState.Clear:
                         break;
 
-                    case State.Set:
+                    case QueueState.Set:
                         isStopped = false;
-                        queue.State = State.Clear;
+                        queue.State = QueueState.Clear;
                         return false;
                 }
 
@@ -350,8 +464,60 @@ namespace System.Net.Sockets
             }
         }
 
+        public SocketError Accept(byte[] socketAddress, ref int socketAddressLen, int timeout, out int acceptedFd)
+        {
+            Debug.Assert(socketAddress != null);
+            Debug.Assert(socketAddressLen > 0);
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            SocketError errorCode;
+            if (SocketPal.TryCompleteAccept(_fileDescriptor, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode))
+            {
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new AcceptOperation {
+                    Event = @event,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error reasonable for a closed socket? Check with Winsock.
+                        acceptedFd = -1;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        socketAddressLen = operation.SocketAddressLen;
+                        acceptedFd = operation.AcceptedFileDescriptor;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                if (!operation.Wait(timeout))
+                {
+                    acceptedFd = -1;
+                    return SocketError.TimedOut;
+                }
+
+                socketAddressLen = operation.SocketAddressLen;
+                acceptedFd = operation.AcceptedFileDescriptor;
+                return operation.ErrorCode;
+            }
+        }
+
         public SocketError AcceptAsync(byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, SocketError> callback)
         {
+            Debug.Assert(socketAddress != null);
+            Debug.Assert(socketAddressLen > 0);
             Debug.Assert(callback != null);
 
             int acceptedFd;
@@ -382,22 +548,56 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteAccept(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
-        private static bool TryCompleteAccept(int fileDescriptor, AcceptOperation operation)
+        public SocketError Connect(byte[] socketAddress, int socketAddressLen, int timeout)
         {
-            return SocketPal.TryCompleteAccept(fileDescriptor, operation.SocketAddress, ref operation.SocketAddressLen, out operation.AcceptedFileDescriptor, out operation.ErrorCode);
+            Debug.Assert(socketAddress != null);
+            Debug.Assert(socketAddressLen > 0);
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            SocketError errorCode;
+            if (SocketPal.TryStartConnect(_fileDescriptor, socketAddress, socketAddressLen, out errorCode))
+            {
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new ConnectOperation {
+                    Event = @event,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error reasonable for a closed socket? Check with Winsock.
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        return operation.ErrorCode;
+                    }
+                }
+
+                return operation.Wait(timeout) ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError ConnectAsync(byte[] socketAddress, int socketAddressLen, Action<SocketError> callback)
@@ -429,27 +629,82 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteConnect(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
-        private static bool TryCompleteConnect(int fileDescriptor, ConnectOperation operation)
+        public SocketError Receive(byte[] buffer, int offset, int count, ref int flags, int timeout, out int bytesReceived)
         {
-            return SocketPal.TryCompleteConnect(fileDescriptor, operation.SocketAddressLen, out operation.ErrorCode);
+            int socketAddressLen = 0;
+            return ReceiveFrom(buffer, offset, count, ref flags, null, ref socketAddressLen, timeout, out bytesReceived);
         }
 
         public SocketError ReceiveAsync(byte[] buffer, int offset, int count, int flags, Action<int, byte[], int, int, SocketError> callback)
         {
             return ReceiveFromAsync(buffer, offset, count, flags, null, 0, callback);
+        }
+
+        public SocketError ReceiveFrom(byte[] buffer, int offset, int count, ref int flags, byte[] socketAddress, ref int socketAddressLen, int timeout, out int bytesReceived)
+        {
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            int receivedFlags;
+            SocketError errorCode;
+            if (SocketPal.TryCompleteReceiveFrom(_fileDescriptor, buffer, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+            {
+                flags = receivedFlags;
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new ReceiveOperation {
+                    Event = @event,
+                    Buffer = buffer,
+                    Offset = offset,
+                    Count = count,
+                    Flags = flags,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen,
+                    BytesTransferred = bytesReceived,
+                    ReceivedFlags = receivedFlags
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error code reasonable for a closed socket? Check with Winsock.
+                        flags = operation.ReceivedFlags;
+                        bytesReceived = operation.BytesTransferred;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        socketAddressLen = operation.SocketAddressLen;
+                        flags = operation.ReceivedFlags;
+                        bytesReceived = operation.BytesTransferred;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                bool signaled = operation.Wait(timeout);
+                socketAddressLen = operation.SocketAddressLen;
+                flags = operation.ReceivedFlags;
+                bytesReceived = operation.BytesTransferred;
+                return signaled ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError ReceiveFromAsync(byte[] buffer, int offset, int count, int flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, int, SocketError> callback)
@@ -470,7 +725,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            var operation = new SendReceiveOperation {
+            var operation = new ReceiveOperation {
                 Callback = callback,
                 Buffer = buffer,
                 Offset = offset,
@@ -489,22 +744,79 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteReceiveFrom(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
+        public SocketError Receive(IList<ArraySegment<byte>> buffers, ref int flags, int timeout, out int bytesReceived)
+        {
+            return ReceiveFrom(buffers, ref flags, null, 0, timeout, out bytesReceived);
+        }
+
         public SocketError ReceiveAsync(IList<ArraySegment<byte>> buffers, int flags, Action<int, byte[], int, int, SocketError> callback)
         {
             return ReceiveFromAsync(buffers, flags, null, 0, callback);
+        }
+
+        public SocketError ReceiveFrom(IList<ArraySegment<byte>> buffers, ref int flags, byte[] socketAddress, int socketAddressLen, int timeout, out int bytesReceived)
+        {
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            int receivedFlags;
+            SocketError errorCode;
+            if (SocketPal.TryCompleteReceiveFrom(_fileDescriptor, buffers, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+            {
+                flags = receivedFlags;
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new ReceiveOperation {
+                    Event = @event,
+                    Buffers = new BufferList(buffers),
+                    Flags = flags,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen,
+                    BytesTransferred = bytesReceived,
+                    ReceivedFlags = receivedFlags
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error code reasonable for a closed socket? Check with Winsock.
+                        flags = operation.ReceivedFlags;
+                        bytesReceived = operation.BytesTransferred;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        socketAddressLen = operation.SocketAddressLen;
+                        flags = operation.ReceivedFlags;
+                        bytesReceived = operation.BytesTransferred;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                bool signaled = operation.Wait(timeout);
+                socketAddressLen = operation.SocketAddressLen;
+                flags = operation.ReceivedFlags;
+                bytesReceived = operation.BytesTransferred;
+                return signaled ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError ReceiveFromAsync(IList<ArraySegment<byte>> buffers, int flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, int, SocketError> callback)
@@ -525,10 +837,12 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            var operation = new SendReceiveOperation {
+            var operation = new ReceiveOperation {
                 Callback = callback,
                 Buffers = new BufferList(buffers),
                 Flags = flags,
+                SocketAddress = socketAddress,
+                SocketAddressLen = socketAddressLen,
                 BytesTransferred = bytesReceived,
                 ReceivedFlags = receivedFlags
             };
@@ -540,22 +854,78 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteReceiveFrom(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
-        private static bool TryCompleteReceiveFrom(int fileDescriptor, SendReceiveOperation operation)
+        public SocketError ReceiveMessageFrom(byte[] buffer, int offset, int count, ref int flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, int timeout, out IPPacketInformation ipPacketInformation, out int bytesReceived)
         {
-            return SocketPal.TryCompleteReceiveFrom(fileDescriptor, operation.Buffer, operation.Buffers, operation.Offset, operation.Count, operation.Flags, operation.SocketAddress, ref operation.SocketAddressLen, out operation.BytesTransferred, out operation.ReceivedFlags, out operation.ErrorCode);
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            int receivedFlags;
+            SocketError errorCode;
+            if (SocketPal.TryCompleteReceiveMessageFrom(_fileDescriptor, buffer, offset, count, flags, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, out errorCode))
+            {
+                flags = receivedFlags;
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new ReceiveMessageFromOperation {
+                    Event = @event,
+                    Buffer = buffer,
+                    Offset = offset,
+                    Count = count,
+                    Flags = flags,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen,
+                    IsIPv4 = isIPv4,
+                    IsIPv6 = isIPv6,
+                    BytesTransferred = bytesReceived,
+                    ReceivedFlags = receivedFlags,
+                    IPPacketInformation = ipPacketInformation,
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error code reasonable for a closed socket? Check with Winsock.
+                        socketAddressLen = operation.SocketAddressLen;
+                        flags = operation.ReceivedFlags;
+                        ipPacketInformation = operation.IPPacketInformation;
+                        bytesReceived = operation.BytesTransferred;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        socketAddressLen = operation.SocketAddressLen;
+                        flags = operation.ReceivedFlags;
+                        ipPacketInformation = operation.IPPacketInformation;
+                        bytesReceived = operation.BytesTransferred;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                bool signaled = operation.Wait(timeout);
+                socketAddressLen = operation.SocketAddressLen;
+                flags = operation.ReceivedFlags;
+                ipPacketInformation = operation.IPPacketInformation;
+                bytesReceived = operation.BytesTransferred;
+                return signaled ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError ReceiveMessageFromAsync(byte[] buffer, int offset, int count, int flags, byte[] socketAddress, int socketAddressLen, bool isIPv4, bool isIPv6, Action<int, byte[], int, int, IPPacketInformation, SocketError> callback)
@@ -599,38 +969,74 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteReceiveMessageFrom(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
-        private static bool TryCompleteReceiveMessageFrom(int fileDescriptor, ReceiveMessageFromOperation operation)
+        public SocketError Send(byte[] buffer, int offset, int count, int flags, int timeout, out int bytesSent)
         {
-            return SocketPal.TryCompleteReceiveMessageFrom(fileDescriptor, operation.Buffer, operation.Offset, operation.Count, operation.Flags, operation.SocketAddress, ref operation.SocketAddressLen, operation.IsIPv4, operation.IsIPv6, out operation.BytesTransferred, out operation.ReceivedFlags, out operation.IPPacketInformation, out operation.ErrorCode);
-        }
-
-        private static bool TryCompleteReceive(int fileDescriptor, TransferOperation operation)
-        {
-            var sendReceiveOperation = operation as SendReceiveOperation;
-            if (sendReceiveOperation != null)
-            {
-                return TryCompleteReceiveFrom(fileDescriptor, sendReceiveOperation);
-            }
-
-            return TryCompleteReceiveMessageFrom(fileDescriptor, (ReceiveMessageFromOperation)operation);
+            return SendTo(buffer, offset, count, flags, null, 0, timeout, out bytesSent);
         }
 
         public SocketError SendAsync(byte[] buffer, int offset, int count, int flags, Action<int, byte[], int, int, SocketError> callback)
         {
             return SendToAsync(buffer, offset, count, flags, null, 0, callback);
+        }
+
+        public SocketError SendTo(byte[] buffer, int offset, int count, int flags, byte[] socketAddress, int socketAddressLen, int timeout, out int bytesSent)
+        {
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            bytesSent = 0;
+            SocketError errorCode;
+            if (SocketPal.TryCompleteSendTo(_fileDescriptor, buffer, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+            {
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new SendOperation {
+                    Event = @event,
+                    Buffer = buffer,
+                    Offset = offset,
+                    Count = count,
+                    Flags = flags,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen,
+                    BytesTransferred = bytesSent
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _sendQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error code reasonable for a closed socket? Check with Winsock.
+                        bytesSent = operation.BytesTransferred;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        bytesSent = operation.BytesTransferred;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                bool signaled = operation.Wait(timeout);
+                bytesSent = operation.BytesTransferred;
+                return signaled ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError SendToAsync(byte[] buffer, int offset, int count, int flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, int, SocketError> callback)
@@ -650,7 +1056,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            var operation = new SendReceiveOperation {
+            var operation = new SendOperation {
                 Callback = callback,
                 Buffer = buffer,
                 Offset = offset,
@@ -668,22 +1074,76 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteSendTo(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
+        public SocketError Send(BufferList buffers, int flags, int timeout, out int bytesSent)
+        {
+            return SendTo(buffers, flags, null, 0, timeout, out bytesSent);
+        }
+
         public SocketError SendAsync(BufferList buffers, int flags, Action<int, byte[], int, int, SocketError> callback)
         {
             return SendToAsync(buffers, flags, null, 0, callback);
+        }
+
+        public SocketError SendTo(BufferList buffers, int flags, byte[] socketAddress, int socketAddressLen, int timeout, out int bytesSent)
+        {
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            bytesSent = 0;
+            int bufferIndex = 0;
+            int offset = 0;
+            SocketError errorCode;
+            if (SocketPal.TryCompleteSendTo(_fileDescriptor, buffers, ref bufferIndex, ref offset, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+            {
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new SendOperation {
+                    Event = @event,
+                    Buffers = buffers,
+                    BufferIndex = bufferIndex,
+                    Offset = offset,
+                    Flags = flags,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen,
+                    BytesTransferred = bytesSent
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _sendQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error code reasonable for a closed socket? Check with Winsock.
+                        bytesSent = operation.BytesTransferred;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        bytesSent = operation.BytesTransferred;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                bool signaled = operation.Wait(timeout);
+                bytesSent = operation.BytesTransferred;
+                return signaled ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError SendToAsync(BufferList buffers, int flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, int, SocketError> callback)
@@ -705,7 +1165,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            var operation = new SendReceiveOperation {
+            var operation = new SendOperation {
                 Callback = callback,
                 Buffers = buffers,
                 BufferIndex = bufferIndex,
@@ -723,27 +1183,17 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteSendTo(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
-        }
-
-        private static bool TryCompleteSendTo(int fileDescriptor, SendReceiveOperation operation)
-        {
-            return SocketPal.TryCompleteSendTo(fileDescriptor, operation.Buffer, operation.Buffers, ref operation.BufferIndex, ref operation.Offset, ref operation.Count, operation.Flags, operation.SocketAddress, operation.SocketAddressLen, ref operation.BytesTransferred, out operation.ErrorCode);
-        }
-
-        private static void QueueCompletion(AsyncOperation operation)
-        {
-            ThreadPool.QueueUserWorkItem(o => ((AsyncOperation)o).Complete(), operation);
         }
 
         public unsafe void HandleEvents(SocketAsyncEvents events)
@@ -769,9 +1219,9 @@ namespace System.Net.Sockets
 
                 if ((events & SocketAsyncEvents.Error) != 0)
                 {
-					// We should only receive error events in conjuntction with other events.
-					// Processing for those events will pick up the error.
-					Debug.Assert((events & ~SocketAsyncEvents.Error) != 0);
+                    // We should only receive error events in conjuntction with other events.
+                    // Processing for those events will pick up the error.
+                    Debug.Assert((events & ~SocketAsyncEvents.Error) != 0);
                 }
 
                 if ((events & SocketAsyncEvents.ReadClose) != 0)
@@ -788,10 +1238,9 @@ namespace System.Net.Sockets
                     while (!receiveQueue.IsEmpty)
                     {
                         TransferOperation op = receiveQueue.Head;
-                        bool completed = TryCompleteReceive(_fileDescriptor, op);
+                        bool completed = op.TryCompleteAsync(_fileDescriptor);
                         Debug.Assert(completed);
                         receiveQueue.Dequeue();
-                        QueueCompletion(op);
                     }
 
                     lock (_queueLock)
@@ -814,24 +1263,23 @@ namespace System.Net.Sockets
                     lock (_queueLock)
                     {
                         acceptTail = _acceptOrConnectQueue.Tail as AcceptOperation;
-						_acceptOrConnectQueue.State = State.Set;
+                        _acceptOrConnectQueue.State = QueueState.Set;
 
                         receiveTail = _receiveQueue.Tail;
-                        _receiveQueue.State = State.Set;
+                        _receiveQueue.State = QueueState.Set;
                     }
 
                     if (acceptTail != null)
                     {
-                        AcceptOperation op;
+                        AcceptOrConnectOperation op;
                         do
                         {
-                            op = (AcceptOperation)_acceptOrConnectQueue.Head;
-                            if (TryCompleteAccept(_fileDescriptor, op))
+                            op = _acceptOrConnectQueue.Head;
+                            if (!op.TryCompleteAsync(_fileDescriptor))
                             {
-                                EndOperation(ref _acceptOrConnectQueue);
-                                QueueCompletion(op);
+                                break;
                             }
-                            break;
+                            EndOperation(ref _acceptOrConnectQueue);
                         } while (op != acceptTail);
                     }
 
@@ -841,12 +1289,11 @@ namespace System.Net.Sockets
                         do
                         {
                             op = _receiveQueue.Head;
-                            if (TryCompleteReceive(_fileDescriptor, op))
+                            if (!op.TryCompleteAsync(_fileDescriptor))
                             {
-                                EndOperation(ref _receiveQueue);
-                                QueueCompletion(op);
+                                break;
                             }
-                            break;
+                            EndOperation(ref _receiveQueue);
                         } while (op != receiveTail);
                     }
                 }
@@ -854,51 +1301,41 @@ namespace System.Net.Sockets
                 if ((events & SocketAsyncEvents.Write) != 0)
                 {
                     AcceptOrConnectOperation connectTail;
-                    SendReceiveOperation sendTail;
+                    SendOperation sendTail;
                     lock (_queueLock)
                     {
                         connectTail = _acceptOrConnectQueue.Tail as ConnectOperation;
-                        _acceptOrConnectQueue.State = State.Set;
+                        _acceptOrConnectQueue.State = QueueState.Set;
 
                         sendTail = _sendQueue.Tail;
-                        _sendQueue.State = State.Set;
+                        _sendQueue.State = QueueState.Set;
                     }
 
                     if (connectTail != null)
                     {
-                        ConnectOperation op;
+                        AcceptOrConnectOperation op;
                         do
                         {
-                            op = (ConnectOperation)_acceptOrConnectQueue.Head;
-                            if (TryCompleteConnect(_fileDescriptor, op))
+                            op = _acceptOrConnectQueue.Head;
+                            if (!op.TryCompleteAsync(_fileDescriptor))
                             {
-                                EndOperation(ref _acceptOrConnectQueue);
-
-                                // The only situation in which we should see EISCONN when completing an
-                                // async connect is if this earlier connect completed successfully:
-                                // POSIX does not allow more than one outstanding async connect.
-                                if (op.ErrorCode == SocketError.IsConnected)
-                                {
-                                    op.ErrorCode = SocketError.Success;
-                                }
-                                QueueCompletion(op);
+                                break;
                             }
-                            break;
+                            EndOperation(ref _acceptOrConnectQueue);
                         } while (op != connectTail);
                     }
 
                     if (sendTail != null)
                     {
-                        SendReceiveOperation op;
+                        SendOperation op;
                         do
                         {
                             op = _sendQueue.Head;
-                            if (TryCompleteSendTo(_fileDescriptor, op))
+                            if (!op.TryCompleteAsync(_fileDescriptor))
                             {
-                                EndOperation(ref _sendQueue);
-                                QueueCompletion(op);
+                                break;
                             }
-                            break;
+                            EndOperation(ref _sendQueue);
                         } while (op != sendTail);
                     }
                 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -47,7 +47,7 @@ namespace System.Net.Sockets
                                     }
                                     catch (Exception e)
                                     {
-                                        Debug.Fail("Exception thrown from event loop: {0}", e.Message);
+                                        Debug.Fail(string.Format("Exception thrown from event loop: {0}", e.Message));
                                     }
                                 }
                             }, engine, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -38,12 +38,14 @@ namespace System.Net.Sockets
                         if (_engine == null)
                         {
                             var engine = new SocketAsyncEngine(SocketAsyncEngineBackend.Create());
-                            Task.Factory.StartNew(o => {
+                            Task.Factory.StartNew(o =>
+                            {
+                                SocketAsyncEngineBackend backend = ((SocketAsyncEngine)o)._backend;
                                 for (;;)
                                 {
                                     try
                                     {
-                                        ((SocketAsyncEngine)o)._backend.EventLoop();
+                                        backend.EventLoop();
                                     }
                                     catch (Exception e)
                                     {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -39,7 +39,17 @@ namespace System.Net.Sockets
                         {
                             var engine = new SocketAsyncEngine(SocketAsyncEngineBackend.Create());
                             Task.Factory.StartNew(o => {
-                                ((SocketAsyncEngine)o)._backend.EventLoop();
+                                for (;;)
+                                {
+                                    try
+                                    {
+                                        ((SocketAsyncEngine)o)._backend.EventLoop();
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        Debug.Fail("Exception thrown from event loop: {0}", e.Message);
+                                    }
+                                }
                             }, engine, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
                             Volatile.Write(ref _engine, engine);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.Linux.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.Linux.cs
@@ -85,7 +85,10 @@ namespace System.Net.Sockets
 
                     var handle = (GCHandle)events[i].data;
                     var context = (SocketAsyncContext)handle.Target;
-                    context.HandleEvents(GetSocketAsyncEvents(evts));
+                    if (context != null)
+                    {
+                        context.HandleEvents(GetSocketAsyncEvents(evts));
+                    }
                 }
             }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.Linux.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.Linux.cs
@@ -72,9 +72,20 @@ namespace System.Net.Sockets
 
                 for (int i = 0; i < numEvents; i++)
                 {
+                    uint evts = events[i].events;
+
+                    // epoll does not play well with disconnected connection-oriented sockets, frequently
+                    // reporting spurious EPOLLHUP events. Fortunately, EPOLLHUP may be handled as an
+                    // EPOLLIN | EPOLLOUT event: the usual processing for these events will recognize and
+                    // handle the HUP condition.
+                    if ((evts & Interop.libc.EPOLLHUP) != 0)
+                    {
+                        evts = (evts & ~Interop.libc.EPOLLHUP) | Interop.libc.EPOLLIN | Interop.libc.EPOLLOUT;
+                    }
+
                     var handle = (GCHandle)events[i].data;
                     var context = (SocketAsyncContext)handle.Target;
-                    context.HandleEvents(GetSocketAsyncEvents(events[i].events));
+                    context.HandleEvents(GetSocketAsyncEvents(evts));
                 }
             }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.OSX.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.OSX.cs
@@ -87,7 +87,11 @@ namespace System.Net.Sockets
                 {
                     var handle = (GCHandle)(IntPtr)events[i].udata;
                     var context = (SocketAsyncContext)handle.Target;
-                    context.HandleEvents(GetSocketAsyncEvents(events[i].filter, events[i].flags));
+
+                    if (context != null)
+                    {
+                        context.HandleEvents(GetSocketAsyncEvents(events[i].filter, events[i].flags));
+                    }
                 }
             }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.OSX.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.OSX.cs
@@ -45,9 +45,14 @@ namespace System.Net.Sockets
 
                 case Interop.libc.EVFILT_WRITE:
                     events = SocketAsyncEvents.Write;
+
+                    // kqueue does not play well with disconnected connection-oriented sockets, frequently
+                    // reporting spurious EOF events. Fortunately, EOF may be handled as an EVFILT_READ |
+                    // EVFILT_WRITE event: the usual processing for these events will recognize and
+                    // handle the EOF condition.
                     if ((flags & Interop.libc.EV_EOF) != 0)
                     {
-                        events |= SocketAsyncEvents.Close;
+                        events |= SocketAsyncEvents.Read;
                     }
                     break;
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -255,7 +255,7 @@ namespace System.Net.Sockets
 
         private SocketError FinishOperationAccept(Internals.SocketAddress remoteSocketAddress)
         {
-            System.Buffer.BlockCopy(m_AcceptBuffer, 0, remoteSocketAddress.Buffer, 0, _socketAddressSize);
+            System.Buffer.BlockCopy(m_AcceptBuffer, 0, remoteSocketAddress.Buffer, 0, m_AcceptAddressBufferCount);
             m_AcceptSocket = _currentSocket.CreateAcceptSocket(
                 SafeCloseSocket.CreateSocket(_acceptedFileDescriptor),
                 _currentSocket.m_RightEndPoint.Create(remoteSocketAddress));

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -275,8 +275,7 @@ namespace System.Net.Sockets
 
         private unsafe void FinishOperationReceiveMessageFrom()
         {
-            // TODO: implement this.
-            throw new NotImplementedException();
+            // No-op for *nix.
         }
 
         private void FinishOperationSendPackets()

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Linux.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Linux.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace System.Net.Sockets
+{
+    internal static partial class SocketPal
+    {
+        public const bool SupportsMultipleConnectAttempts = true;
+
+        public static unsafe void PrimeForNextConnectAttempt(int fileDescriptor, int socketAddressLen)
+        {
+            // On Linux, a non-blocking socket that fails a connect() attempt needs to be kicked
+            // with another connect to AF_UNSPEC before further connect() attempts will return
+            // valid errors. Otherwise, further connect() attempts will return ECONNABORTED.
+            
+            var socketAddressBuffer = stackalloc byte[socketAddressLen];
+            var sockAddr = (Interop.libc.sockaddr*)socketAddressBuffer;
+            sockAddr->sa_family = Interop.libc.AF_UNSPEC;
+
+            int err = Interop.libc.connect(fileDescriptor, sockAddr, (uint)socketAddressLen);
+            Debug.Assert(err == 0, "TryCompleteConnect: failed to disassociate socket after failed connect()");
+        }
+    }
+}

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.OSX.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.OSX.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace System.Net.Sockets
+{
+    internal static partial class SocketPal
+    {
+        public const bool SupportsMultipleConnectAttempts = false;
+
+        public static void PrimeForNextConnectAttempt(int fileDescriptor, int socketAddressLen)
+        {
+            Debug.Fail("This should never be called!");
+        }
+    }
+}

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1213,7 +1213,14 @@ namespace System.Net.Sockets
 
         public static SocketError Connect(SafeCloseSocket handle, byte[] socketAddress, int socketAddressLen)
         {
-            return handle.AsyncContext.Connect(socketAddress, socketAddressLen, -1);
+            if (!handle.IsNonBlocking)
+            {
+                return handle.AsyncContext.Connect(socketAddress, socketAddressLen, -1);
+            }
+
+            SocketError errorCode;
+            bool completed = SocketPal.TryStartConnect(handle.FileDescriptor, socketAddress, socketAddressLen, out errorCode);
+            return completed ? errorCode : SocketError.WouldBlock;
         }
 
         public static SocketError Disconnect(Socket socket, SafeCloseSocket handle, bool reuseSocket)
@@ -1223,28 +1230,88 @@ namespace System.Net.Sockets
 
         public static SocketError Send(SafeCloseSocket handle, BufferOffsetSize[] buffers, SocketFlags socketFlags, out int bytesTransferred)
         {
-            return handle.AsyncContext.Send(new BufferList(buffers), GetPlatformSocketFlags(socketFlags), handle.SendTimeout, out bytesTransferred);
+            var bufferList = new BufferList(buffers);
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            if (!handle.IsNonBlocking)
+            {
+                return handle.AsyncContext.Send(bufferList, platformFlags, handle.SendTimeout, out bytesTransferred);
+            }
+
+            bytesTransferred = 0;
+            int bufferIndex = 0;
+            int offset = 0;
+            SocketError errorCode;
+            bool completed = TryCompleteSendTo(handle.FileDescriptor, bufferList, ref bufferIndex, ref offset, platformFlags, null, 0, ref bytesTransferred, out errorCode);
+            return completed ? errorCode : SocketError.WouldBlock;
         }
 
         public static SocketError Send(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out int bytesTransferred)
         {
-            return handle.AsyncContext.Send(new BufferList(buffers), GetPlatformSocketFlags(socketFlags), handle.SendTimeout, out bytesTransferred);
+            var bufferList = new BufferList(buffers);
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            if (!handle.IsNonBlocking)
+            {
+                return handle.AsyncContext.Send(bufferList, platformFlags, handle.SendTimeout, out bytesTransferred);
+            }
+
+            bytesTransferred = 0;
+            int bufferIndex = 0;
+            int offset = 0;
+            SocketError errorCode;
+            bool completed = TryCompleteSendTo(handle.FileDescriptor, bufferList, ref bufferIndex, ref offset, platformFlags, null, 0, ref bytesTransferred, out errorCode);
+            return completed ? errorCode : SocketError.WouldBlock;
         }
 
         public static SocketError Send(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, out int bytesTransferred)
         {
-            return handle.AsyncContext.Send(buffer, offset, count, GetPlatformSocketFlags(socketFlags), handle.SendTimeout, out bytesTransferred);
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            if (!handle.IsNonBlocking)
+            {
+                return handle.AsyncContext.Send(buffer, offset, count, platformFlags, handle.SendTimeout, out bytesTransferred);
+            }
+
+            bytesTransferred = 0;
+            SocketError errorCode;
+            bool completed = TryCompleteSendTo(handle.FileDescriptor, buffer, ref offset, ref count, platformFlags, null, 0, ref bytesTransferred, out errorCode);
+            return completed ? errorCode : SocketError.WouldBlock;
         }
 
         public static SocketError SendTo(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, byte[] socketAddress, int socketAddressLen, out int bytesTransferred)
         {
-            return handle.AsyncContext.SendTo(buffer, offset, count, GetPlatformSocketFlags(socketFlags), socketAddress, socketAddressLen, handle.SendTimeout, out bytesTransferred);
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            if (!handle.IsNonBlocking)
+            {
+                return handle.AsyncContext.SendTo(buffer, offset, count, platformFlags, socketAddress, socketAddressLen, handle.SendTimeout, out bytesTransferred);
+            }
+
+            bytesTransferred = 0;
+            SocketError errorCode;
+            bool completed = TryCompleteSendTo(handle.FileDescriptor, buffer, ref offset, ref count, platformFlags, socketAddress, socketAddressLen, ref bytesTransferred, out errorCode);
+            return completed ? errorCode : SocketError.WouldBlock;
         }
 
         public static SocketError Receive(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, ref SocketFlags socketFlags, out int bytesTransferred)
         {
             int platformFlags = GetPlatformSocketFlags(socketFlags);
-            SocketError errorCode = handle.AsyncContext.Receive(buffers, ref platformFlags, handle.ReceiveTimeout, out bytesTransferred);
+
+            SocketError errorCode;
+            if (!handle.IsNonBlocking)
+            {
+                errorCode = handle.AsyncContext.Receive(buffers, ref platformFlags, handle.ReceiveTimeout, out bytesTransferred);
+            }
+            else
+            {
+                int socketAddressLen = 0;
+                if (!TryCompleteReceiveFrom(handle.FileDescriptor, buffers, platformFlags, null, ref socketAddressLen, out bytesTransferred, out platformFlags, out errorCode))
+                {
+                    errorCode = SocketError.WouldBlock;
+                }
+            }
+
             socketFlags = GetSocketFlags(platformFlags);
             return errorCode;
         }
@@ -1252,7 +1319,16 @@ namespace System.Net.Sockets
         public static SocketError Receive(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, out int bytesTransferred)
         {
             int platformFlags = GetPlatformSocketFlags(socketFlags);
-            return handle.AsyncContext.Receive(buffer, offset, count, ref platformFlags, handle.ReceiveTimeout, out bytesTransferred);
+
+            if (!handle.IsNonBlocking)
+            {
+                return handle.AsyncContext.Receive(buffer, offset, count, ref platformFlags, handle.ReceiveTimeout, out bytesTransferred);
+            }
+
+            int socketAddressLen = 0;
+            SocketError errorCode;
+            bool completed = TryCompleteReceiveFrom(handle.FileDescriptor, buffer, offset, count, platformFlags, null, ref socketAddressLen, out bytesTransferred, out platformFlags, out errorCode);
+            return completed ? errorCode : SocketError.WouldBlock;
         }
 
         public static SocketError ReceiveMessageFrom(Socket socket, SafeCloseSocket handle, byte[] buffer, int offset, int count, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
@@ -1264,8 +1340,19 @@ namespace System.Net.Sockets
             bool isIPv4, isIPv6;
             Socket.GetIPProtocolInformation(socket.AddressFamily, socketAddress, out isIPv4, out isIPv6);
 
-            SocketError errorCode = handle.AsyncContext.ReceiveMessageFrom(buffer, offset, count, ref platformFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, handle.ReceiveTimeout, out ipPacketInformation, out bytesTransferred);
-            
+            SocketError errorCode;
+            if (!handle.IsNonBlocking)
+            {
+                errorCode = handle.AsyncContext.ReceiveMessageFrom(buffer, offset, count, ref platformFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, handle.ReceiveTimeout, out ipPacketInformation, out bytesTransferred);
+            }
+            else
+            {
+                if (!TryCompleteReceiveMessageFrom(handle.FileDescriptor, buffer, offset, count, platformFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out platformFlags, out ipPacketInformation, out errorCode))
+                {
+                    errorCode = SocketError.WouldBlock;
+                }
+            }
+
             socketAddress.InternalSize = socketAddressLen;
             receiveAddress = socketAddress;
             socketFlags = GetSocketFlags(platformFlags);
@@ -1275,7 +1362,15 @@ namespace System.Net.Sockets
         public static SocketError ReceiveFrom(SafeCloseSocket handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, byte[] socketAddress, ref int socketAddressLen, out int bytesTransferred)
         {
             int platformFlags = GetPlatformSocketFlags(socketFlags);
-            return handle.AsyncContext.ReceiveFrom(buffer, offset, count, ref platformFlags, socketAddress, ref socketAddressLen, handle.ReceiveTimeout, out bytesTransferred);
+
+            if (!handle.IsNonBlocking)
+            {
+                return handle.AsyncContext.ReceiveFrom(buffer, offset, count, ref platformFlags, socketAddress, ref socketAddressLen, handle.ReceiveTimeout, out bytesTransferred);
+            }
+
+            SocketError errorCode;
+            bool completed = TryCompleteReceiveFrom(handle.FileDescriptor, buffer, offset, count, platformFlags, socketAddress, ref socketAddressLen, out bytesTransferred, out platformFlags, out errorCode);
+            return completed ? errorCode : SocketError.WouldBlock;
         }
 
         public static SocketError Ioctl(SafeCloseSocket handle, int ioControlCode, byte[] optionInValue, byte[] optionOutValue, out int optionLength)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -530,16 +530,596 @@ namespace System.Net.Sockets
             throw new PlatformNotSupportedException();
         }
 
-        public static SocketError SetBlocking(SafeCloseSocket handle, bool shouldBlock, out bool willBlock)
+        public static unsafe bool Poll(int fd, Interop.libc.PollFlags events, out SocketError errorCode)
         {
-            int err = Interop.Sys.Fcntl.SetIsNonBlocking(handle.FileDescriptor, shouldBlock ? 0 : 1);
-            if (err == -1)
+            // TODO: respect send/receive timeouts?
+
+            var pollfd = new Interop.libc.pollfd {
+                fd = fd,
+                events = events
+            };
+
+            int nfds = Interop.libc.poll(&pollfd, 1, -1);
+            if (nfds != 1)
             {
-                // TODO: consider this value
-                willBlock = shouldBlock;
-                return GetLastSocketError();
+                errorCode = nfds == 0 ? SocketError.SocketError : GetLastSocketError();
+                return false;
             }
 
+            if ((pollfd.revents & events) == 0)
+            {
+                errorCode = SocketError.SocketError;
+                return false;
+            }
+
+            errorCode = SocketError.Success;
+            return true;
+        }
+
+        private static unsafe int Receive(int fd, int flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, out int receivedFlags, out Interop.Error errno)
+        {
+            Debug.Assert(socketAddress != null || socketAddressLen == 0);
+
+            var pinnedSocketAddress = default(GCHandle);
+            Interop.libc.sockaddr* sockAddr = null;
+            uint sockAddrLen = 0;
+
+            int received;
+            try
+            {
+                if (socketAddress != null)
+                {
+                    pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
+                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddrLen = (uint)socketAddressLen;
+                }
+
+                fixed (byte* b = buffer)
+                {
+                    var iov = new Interop.libc.iovec {
+                        iov_base = &b[offset],
+                        iov_len = (IntPtr)count
+                    };
+
+                    var msghdr = new Interop.libc.msghdr(sockAddr, sockAddrLen, &iov, 1, null, 0, 0);
+                    received = (int)Interop.libc.recvmsg(fd, &msghdr, flags);
+                    receivedFlags = msghdr.msg_flags;
+                    sockAddrLen = msghdr.msg_namelen;
+                }
+            }
+            finally
+            {
+                if (pinnedSocketAddress.IsAllocated)
+                {
+                    pinnedSocketAddress.Free();
+                }
+            }
+
+            if (received == -1)
+            {
+                errno = Interop.Sys.GetLastError();
+                return -1;
+            }
+
+            socketAddressLen = (int)sockAddrLen;
+            errno = Interop.Error.SUCCESS;
+            return received;
+        }
+
+        private static unsafe int Send(int fd, int flags, byte[] buffer, ref int offset, ref int count, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
+        {
+            var pinnedSocketAddress = default(GCHandle);
+            Interop.libc.sockaddr* sockAddr = null;
+            uint sockAddrLen = 0;
+
+            int sent;
+            try
+            {
+                if (socketAddress != null)
+                {
+                    pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
+                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddrLen = (uint)socketAddressLen;
+                }
+
+                fixed (byte* b = buffer)
+                {
+                    sent = (int)Interop.libc.sendto(fd, &b[offset], (IntPtr)count, flags, sockAddr, sockAddrLen);
+                }
+            }
+            finally
+            {
+                if (pinnedSocketAddress.IsAllocated)
+                {
+                    pinnedSocketAddress.Free();
+                }
+            }
+
+            if (sent == -1)
+            {
+                errno = Interop.Sys.GetLastError();
+                return -1;
+            }
+
+            errno = Interop.Error.SUCCESS;
+            offset += sent;
+            count -= sent;
+            return sent;
+        }
+
+        private static unsafe int Send(int fd, int flags, BufferList buffers, ref int bufferIndex, ref int offset, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
+        {
+            // Pin buffers and set up iovecs
+            int startIndex = bufferIndex, startOffset = offset;
+
+            var pinnedSocketAddress = default(GCHandle);
+            Interop.libc.sockaddr* sockAddr = null;
+            uint sockAddrLen = 0;
+
+            int maxBuffers = buffers.Count - startIndex;
+            var handles = new GCHandle[maxBuffers];
+            var iovecs = new Interop.libc.iovec[maxBuffers];
+
+            int sent;
+            int toSend = 0, iovCount = maxBuffers;
+            try
+            {
+                for (int i = 0; i < maxBuffers; i++, startOffset = 0)
+                {
+                    ArraySegment<byte> buffer = buffers[startIndex + i];
+                    Debug.Assert(buffer.Offset + startOffset < buffer.Array.Length);
+
+                    handles[i] = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
+                    iovecs[i].iov_base = &((byte*)handles[i].AddrOfPinnedObject())[buffer.Offset + startOffset];
+
+                    toSend += (buffer.Count - startOffset);
+                    iovecs[i].iov_len = (IntPtr)(buffer.Count - startOffset);
+                }
+
+                if (socketAddress != null)
+                {
+                    pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
+                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddrLen = (uint)socketAddressLen;
+                }
+
+                // Make the call
+                fixed (Interop.libc.iovec* iov = iovecs)
+                {
+                    var msghdr = new Interop.libc.msghdr(sockAddr, sockAddrLen, iov, iovCount, null, 0, 0);
+                    sent = (int)Interop.libc.sendmsg(fd, &msghdr, flags);
+                }
+                errno = Interop.Sys.GetLastError();
+            }
+            finally
+            {
+                // Free GC handles
+                for (int i = 0; i < iovCount; i++)
+                {
+                    if (handles[i].IsAllocated)
+                    {
+                        handles[i].Free();
+                    }
+                }
+
+                if (pinnedSocketAddress.IsAllocated)
+                {
+                    pinnedSocketAddress.Free();
+                }
+            }
+
+            if (sent == -1)
+            {
+                return -1;
+            }
+
+            // Update position
+            int endIndex = bufferIndex, endOffset = offset, unconsumed = sent;
+            for (; endIndex < buffers.Count && unconsumed > 0; endIndex++, endOffset = 0)
+            {
+                int space = buffers[endIndex].Count - endOffset;
+                if (space > unconsumed)
+                {
+                    endOffset += unconsumed;
+                    break;
+                }
+                unconsumed -= space;
+            }
+
+            bufferIndex = endIndex;
+            offset = endOffset;
+
+            return sent;
+        }
+
+        private static unsafe int Receive(int fd, int flags, int available, BufferList buffers, byte[] socketAddress, ref int socketAddressLen, out int receivedFlags, out Interop.Error errno)
+        {
+            // Pin buffers and set up iovecs
+            int maxBuffers = buffers.Count;
+            var handles = new GCHandle[maxBuffers];
+            var iovecs = new Interop.libc.iovec[maxBuffers];
+
+            var pinnedSocketAddress = default(GCHandle);
+            Interop.libc.sockaddr* sockAddr = null;
+            uint sockAddrLen = 0;
+
+            int received = 0;
+            int toReceive = 0, iovCount = maxBuffers;
+            try
+            {
+                for (int i = 0; i < maxBuffers; i++)
+                {
+                    ArraySegment<byte> buffer = buffers[i];
+                    handles[i] = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
+                    iovecs[i].iov_base = &((byte*)handles[i].AddrOfPinnedObject())[buffer.Offset];
+
+                    int space = buffer.Count;
+                    toReceive += space;
+                    if (toReceive >= available)
+                    {
+                        iovecs[i].iov_len = (IntPtr)(space - (toReceive - available));
+                        toReceive = available;
+                        iovCount = i + 1;
+                        break;
+                    }
+
+                    iovecs[i].iov_len = (IntPtr)space;
+                }
+
+                if (socketAddress != null)
+                {
+                    pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
+                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddrLen = (uint)socketAddressLen;
+                }
+
+                // Make the call
+                fixed (Interop.libc.iovec* iov = iovecs)
+                {
+                    var msghdr = new Interop.libc.msghdr(sockAddr, sockAddrLen, iov, iovCount, null, 0, 0);
+                    received = (int)Interop.libc.recvmsg(fd, &msghdr, flags);
+                    receivedFlags = msghdr.msg_flags;
+                    sockAddrLen = msghdr.msg_namelen;
+                }
+            }
+            finally
+            {
+                // Free GC handles
+                for (int i = 0; i < iovCount; i++)
+                {
+                    if (handles[i].IsAllocated)
+                    {
+                        handles[i].Free();
+                    }
+                }
+
+                if (pinnedSocketAddress.IsAllocated)
+                {
+                    pinnedSocketAddress.Free();
+                }
+            }
+
+            if (received == -1)
+            {
+                errno = Interop.Sys.GetLastError();
+                return -1;
+            }
+
+            socketAddressLen = (int)sockAddrLen;
+            errno = Interop.Error.SUCCESS;
+            return received;
+        }
+
+        private static unsafe int ReceiveMessageFrom(int fd, int flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
+        {
+            Debug.Assert(socketAddress != null);
+
+            var pktinfoLen = isIPv4 ? sizeof(Interop.libc.in_pktinfo) : isIPv6 ? sizeof(Interop.libc.in6_pktinfo) : 0;
+            var cmsgBufferLen = Interop.libc.cmsghdr.Size + pktinfoLen;
+            var cmsgBuffer = stackalloc byte[cmsgBufferLen];
+
+            var sockAddrLen = (uint)socketAddressLen;
+
+            int received;
+            fixed (byte* rawSocketAddress = socketAddress)
+            fixed (byte* b = buffer)
+            {
+                var sockAddr = (Interop.libc.sockaddr*)rawSocketAddress;
+
+                var iov = new Interop.libc.iovec {
+                    iov_base = &b[offset],
+                    iov_len = (IntPtr)count
+                };
+
+                var msghdr = new Interop.libc.msghdr(sockAddr, sockAddrLen, &iov, 1, cmsgBuffer, cmsgBufferLen, 0);
+                received = (int)Interop.libc.recvmsg(fd, &msghdr, flags);
+                receivedFlags = msghdr.msg_flags;
+                sockAddrLen = msghdr.msg_namelen;
+                cmsgBufferLen = (int)msghdr.msg_controllen;
+            }
+
+            ipPacketInformation = SocketPal.GetIPPacketInformation(cmsgBuffer, cmsgBufferLen, isIPv4, isIPv6);
+
+            if (received == -1)
+            {
+                errno = Interop.Sys.GetLastError();
+                return -1;
+            }
+
+            socketAddressLen = (int)sockAddrLen;
+            errno = Interop.Error.SUCCESS;
+            return received;
+        }
+
+        public static unsafe bool TryCompleteAccept(int fileDescriptor, byte[] socketAddress, ref int socketAddressLen, out int acceptedFd, out SocketError errorCode)
+        {
+            int fd;
+            uint sockAddrLen = (uint)socketAddressLen;
+            fixed (byte* rawSocketAddress = socketAddress)
+            {
+                fd = Interop.libc.accept(fileDescriptor, (Interop.libc.sockaddr*)rawSocketAddress, &sockAddrLen);
+            }
+
+            if (fd != -1)
+            {
+                // If the accept completed successfully, ensure that the accepted socket is non-blocking.
+                int err = Interop.Sys.Fcntl.SetIsNonBlocking(fd, 1);
+                if (err == 0)
+                {
+                    socketAddressLen = (int)sockAddrLen;
+                    errorCode = SocketError.Success;
+                    acceptedFd = fd;
+                }
+                else
+                {
+                    Interop.Sys.Close(fd);
+                    errorCode = GetLastSocketError();
+                    acceptedFd = -1;
+                }
+                return true;
+            }
+            acceptedFd = -1;
+
+            Interop.Error errno = Interop.Sys.GetLastError();
+            if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
+            {
+                errorCode = GetSocketErrorForErrorCode(errno);
+                return true;
+            }
+
+            errorCode = SocketError.Success;
+            return false;
+        }
+
+        public static unsafe bool TryStartConnect(int fileDescriptor, byte[] socketAddress, int socketAddressLen, out SocketError errorCode)
+        {
+            Debug.Assert(socketAddress != null);
+            Debug.Assert(socketAddressLen > 0);
+
+            int err;
+            fixed (byte* rawSocketAddress = socketAddress)
+            {
+                var sockAddr = (Interop.libc.sockaddr*)rawSocketAddress;
+                err = Interop.libc.connect(fileDescriptor, sockAddr, (uint)socketAddressLen);
+            }
+
+            if (err == 0)
+            {
+                errorCode = SocketError.Success;
+                return true;
+            }
+
+            Interop.Error errno = Interop.Sys.GetLastError();
+            if (errno != Interop.Error.EINPROGRESS)
+            {
+                errorCode = GetSocketErrorForErrorCode(errno);
+                return true;
+            }
+
+            errorCode = SocketError.Success;
+            return false;
+        }
+
+        public static unsafe bool TryCompleteConnect(int fileDescriptor, int socketAddressLen, out SocketError errorCode)
+        {
+            int socketErrno;
+			var optLen = (uint)sizeof(int);
+            int err = Interop.libc.getsockopt(fileDescriptor, Interop.libc.SOL_SOCKET, Interop.libc.SO_ERROR, &socketErrno, &optLen);
+
+            if (err != 0)
+            {
+                Debug.Fail("TryCompleteConnect: getsockopt() failed");
+                errorCode = SocketError.SocketError;
+                return true;
+            }
+			Debug.Assert(optLen == (uint)sizeof(int));
+
+            Interop.Error socketError = Interop.Sys.ConvertErrorPlatformToPal(socketErrno);
+            if (socketError == Interop.Error.SUCCESS)
+            {
+                errorCode = SocketError.Success;
+                return true;
+            }
+            else if (socketError == Interop.Error.EINPROGRESS)
+            {
+                errorCode = SocketError.Success;
+                return false;
+            }
+
+            errorCode = GetSocketErrorForErrorCode(socketError);
+
+            // On Linux, a non-blocking socket that fails a connect() attempt needs to be kicked
+            // with another connect to AF_UNSPEC before further connect() attempts will return
+            // valid errors. Otherwise, further connect() attempts will return ECONNABORTED.
+            
+            var socketAddressBuffer = stackalloc byte[socketAddressLen];
+            var sockAddr = (Interop.libc.sockaddr*)socketAddressBuffer;
+            sockAddr->sa_family = Interop.libc.AF_UNSPEC;
+
+            err = Interop.libc.connect(fileDescriptor, sockAddr, (uint)socketAddressLen);
+            Debug.Assert(err == 0, "TryCompleteConnect: failed to disassociate socket after failed connect()");
+
+            return true;
+        }
+
+        public static bool TryCompleteReceiveFrom(int fileDescriptor, byte[] buffer, int offset, int count, int flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out int receivedFlags, out SocketError errorCode)
+        {
+            return TryCompleteReceiveFrom(fileDescriptor, buffer, default(BufferList), offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
+        }
+
+        public static bool TryCompleteReceiveFrom(int fileDescriptor, IList<ArraySegment<byte>> buffers, int flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out int receivedFlags, out SocketError errorCode)
+        {
+            return TryCompleteReceiveFrom(fileDescriptor, null, new BufferList(buffers), 0, 0, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
+        }
+
+        public static unsafe bool TryCompleteReceiveFrom(int fileDescriptor, byte[] buffer, BufferList buffers, int offset, int count, int flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out int receivedFlags, out SocketError errorCode)
+        {
+            int available;
+            int err = Interop.libc.ioctl(fileDescriptor, (UIntPtr)Interop.libc.FIONREAD, &available);
+            if (err == -1)
+            {
+                bytesReceived = 0;
+                receivedFlags = 0;
+                errorCode = GetLastSocketError();
+                return true;
+            }
+            if (available == 0)
+            {
+                // Always request at least one byte.
+                available = 1;
+            }
+
+            int received;
+            Interop.Error errno;
+            if (buffer != null)
+            {
+                received = Receive(fileDescriptor, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+            }
+            else
+            {
+                Debug.Assert(buffers.IsInitialized);
+                received = Receive(fileDescriptor, flags, available, buffers, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+            }
+
+            if (received != -1)
+            {
+                bytesReceived = received;
+                errorCode = SocketError.Success;
+                return true;
+            }
+
+            bytesReceived = 0;
+
+            if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
+            {
+                errorCode = GetSocketErrorForErrorCode(errno);
+                return true;
+            }
+
+            errorCode = SocketError.Success;
+            return false;
+        }
+
+        public static unsafe bool TryCompleteReceiveMessageFrom(int fileDescriptor, byte[] buffer, int offset, int count, int flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out int receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
+        {
+            int available;
+            int err = Interop.libc.ioctl(fileDescriptor, (UIntPtr)Interop.libc.FIONREAD, &available);
+            if (err == -1)
+            {
+                bytesReceived = 0;
+                receivedFlags = 0;
+                ipPacketInformation = default(IPPacketInformation);
+                errorCode = GetLastSocketError();
+                return true;
+            }
+            if (available == 0)
+            {
+                // Always request at least one byte.
+                available = 1;
+            }
+
+            Interop.Error errno;
+            int received = ReceiveMessageFrom(fileDescriptor, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno);
+
+            if (received != -1)
+            {
+                bytesReceived = received;
+                errorCode = SocketError.Success;
+                return true;
+            }
+
+            bytesReceived = 0;
+
+            if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
+            {
+                errorCode = GetSocketErrorForErrorCode(errno);
+                return true;
+            }
+
+            errorCode = SocketError.Success;
+            return false;
+        }
+
+        public static bool TryCompleteSendTo(int fileDescriptor, byte[] buffer, ref int offset, ref int count, int flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        {
+            int bufferIndex = 0;
+            return TryCompleteSendTo(fileDescriptor, buffer, default(BufferList), ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+        }
+
+        public static bool TryCompleteSendTo(int fileDescriptor, BufferList buffers, ref int bufferIndex, ref int offset, int flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        {
+            int count = 0;
+            return TryCompleteSendTo(fileDescriptor, null, buffers, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+        }
+
+        public static bool TryCompleteSendTo(int fileDescriptor, byte[] buffer, BufferList buffers, ref int bufferIndex, ref int offset, ref int count, int flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        {
+            for (;;)
+            {
+                int sent;
+                Interop.Error errno;
+                if (buffer != null)
+                {
+                    sent = Send(fileDescriptor, flags, buffer, ref offset, ref count, socketAddress, socketAddressLen, out errno);
+                }
+                else
+                {
+                    Debug.Assert(buffers.IsInitialized);
+                    sent = Send(fileDescriptor, flags, buffers, ref bufferIndex, ref offset, socketAddress, socketAddressLen, out errno);
+                }
+
+                if (sent == -1)
+                {
+                    if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
+                    {
+                        errorCode = GetSocketErrorForErrorCode(errno);
+                        return true;
+                    }
+
+                    errorCode = SocketError.Success;
+                    return false;
+                }
+
+                bytesSent += sent;
+
+                bool isComplete = sent == 0 ||
+                    (buffer != null && count == 0) ||
+                    (buffers.IsInitialized && bufferIndex == buffers.Count);
+                if (isComplete)
+                {
+                    errorCode = SocketError.Success;
+                    return true;
+                }
+            }
+        }
+
+        public static SocketError SetBlocking(SafeCloseSocket handle, bool shouldBlock, out bool willBlock)
+        {
+            // NOTE: since we need to emulate blocking I/O on *nix (!), this does NOT change the blocking
+            //       mode of the socket. Instead, it toggles a bit on the handle to indicate whether or not
+            //       the PAL methods with blocking semantics should retry in the case of an operation that
+            //       cannot be completed synchronously.
+            handle.IsNonBlocking = !shouldBlock;
             willBlock = shouldBlock;
             return SocketError.Success;
         }
@@ -602,23 +1182,25 @@ namespace System.Net.Sockets
             return SafeCloseSocket.Accept(handle, buffer, ref nameLen);
         }
 
-        public static unsafe SocketError Connect(SafeCloseSocket handle, byte[] peerAddress, int peerAddressLen)
+        public static SocketError Connect(SafeCloseSocket handle, byte[] peerAddress, int peerAddressLen)
         {
-            int err;
-            fixed (byte* rawPeerAddress = peerAddress)
+            int fd = handle.FileDescriptor;
+
+            SocketError errorCode;
+            if (!TryStartConnect(fd, peerAddress, peerAddressLen, out errorCode))
             {
-                var peerSockAddr = (Interop.libc.sockaddr*)rawPeerAddress;
-                err = Interop.libc.connect(handle.FileDescriptor, peerSockAddr, (uint)peerAddressLen);
+                return errorCode;
             }
 
-            if (err != -1)
+            while (!TryCompleteConnect(fd, peerAddressLen, out errorCode) && !handle.IsNonBlocking)
             {
-                return SocketError.Success;
+                if (!Poll(fd, Interop.libc.PollFlags.POLLOUT, out errorCode))
+                {
+                    break;
+                }
             }
 
-            // Unix returns EINPROGRESS instead of EWOULDBLOCK for non-blocking connect operations
-            SocketError errorCode = GetLastSocketError();
-            return errorCode == SocketError.InProgress ? SocketError.WouldBlock : errorCode;
+            return errorCode;
         }
 
         public static SocketError Disconnect(Socket socket, SafeCloseSocket handle, bool reuseSocket)
@@ -626,254 +1208,182 @@ namespace System.Net.Sockets
             throw new PlatformNotSupportedException();
         }
 
-        public static unsafe SocketError Send(SafeCloseSocket handle, BufferOffsetSize[] buffers, SocketFlags socketFlags, out int bytesTransferred)
+        public static SocketError Send(SafeCloseSocket handle, BufferOffsetSize[] buffers, SocketFlags socketFlags, out int bytesTransferred)
         {
-            var iovecs = new Interop.libc.iovec[buffers.Length];
-            var handles = new GCHandle[buffers.Length];
+            int fd = handle.FileDescriptor;
+            var bufferList = new BufferList(buffers);
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
 
+            int bufferIndex = 0;
+            int offset = 0;
+            int bytesSent = 0;
 
-            try
+            SocketError errorCode;
+            while (!TryCompleteSendTo(fd, bufferList, ref bufferIndex, ref offset, platformFlags, null, 0, ref bytesSent, out errorCode) && !handle.IsNonBlocking)
             {
-                for (int i = 0; i < buffers.Length; i++)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLOUT, out errorCode))
                 {
-                    handles[i] = GCHandle.Alloc(buffers[i].Buffer, GCHandleType.Pinned);
-                    iovecs[i].iov_base = &((byte*)handles[i].AddrOfPinnedObject())[buffers[i].Offset];
-                    iovecs[i].iov_len = (IntPtr)buffers[i].Size;
-                }
-
-                int sent;
-                fixed (Interop.libc.iovec* iov = iovecs)
-                {
-                    var msghdr = new Interop.libc.msghdr(null, 0, iov, iovecs.Length, null, 0, 0);
-                    sent = (int)Interop.libc.sendmsg(handle.FileDescriptor, &msghdr, GetPlatformSocketFlags(socketFlags));
-                }
-
-                if (sent == -1)
-                {
-                    bytesTransferred = 0;
-                    return GetLastSocketError();
-                }
-
-                bytesTransferred = sent;
-                return SocketError.Success;
-            }
-            finally
-            {
-                for (int i = 0; i < handles.Length; i++)
-                {
-                    if (handles[i].IsAllocated)
-                    {
-                        handles[i].Free();
-                    }
+                    break;
                 }
             }
+
+            bytesTransferred = bytesSent;
+            return errorCode;
         }
 
-        public static unsafe SocketError Send(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out int bytesTransferred)
+        public static SocketError Send(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out int bytesTransferred)
         {
-            var iovecs = new Interop.libc.iovec[buffers.Count];
-            var handles = new GCHandle[buffers.Count];
+            int fd = handle.FileDescriptor;
+            var bufferList = new BufferList(buffers);
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
 
-            try
+            int bufferIndex = 0;
+            int offset = 0;
+            int bytesSent = 0;
+
+            SocketError errorCode;
+            while (!TryCompleteSendTo(fd, bufferList, ref bufferIndex, ref offset, platformFlags, null, 0, ref bytesSent, out errorCode) && !handle.IsNonBlocking)
             {
-                for (int i = 0; i < buffers.Count; i++)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLOUT, out errorCode))
                 {
-                    handles[i] = GCHandle.Alloc(buffers[i].Array, GCHandleType.Pinned);
-                    iovecs[i].iov_base = &((byte*)handles[i].AddrOfPinnedObject())[buffers[i].Offset];
-                    iovecs[i].iov_len = (IntPtr)buffers[i].Count;
-                }
-
-                int sent;
-                fixed (Interop.libc.iovec* iov = iovecs)
-                {
-                    var msghdr = new Interop.libc.msghdr(null, 0, iov, iovecs.Length, null, 0, 0);
-                    sent = (int)Interop.libc.sendmsg(handle.FileDescriptor, &msghdr, GetPlatformSocketFlags(socketFlags));
-                }
-
-                if (sent == -1)
-                {
-                    bytesTransferred = 0;
-                    return GetLastSocketError();
-                }
-
-                bytesTransferred = sent;
-                return SocketError.Success;
-            }
-            finally
-            {
-                for (int i = 0; i < handles.Length; i++)
-                {
-                    if (handles[i].IsAllocated)
-                    {
-                        handles[i].Free();
-                    }
+                    break;
                 }
             }
+
+            bytesTransferred = bytesSent;
+            return errorCode;
         }
 
-        // TODO: refactor to accommodate GetLastSocketError
-        public static unsafe int Send(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        public static SocketError Send(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, out int bytesTransferred)
         {
-            int sent;
-            if (buffer.Length == 0)
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            int bytesSent = 0;
+
+            SocketError errorCode;
+            while (!TryCompleteSendTo(fd, buffer, ref offset, ref size, platformFlags, null, 0, ref bytesSent, out errorCode) && !handle.IsNonBlocking)
             {
-                sent = (int)Interop.libc.send(handle.FileDescriptor, null, IntPtr.Zero, GetPlatformSocketFlags(socketFlags));
-            }
-            else
-            {
-                fixed (byte* pinnedBuffer = buffer)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLOUT, out errorCode))
                 {
-                    sent = (int)Interop.libc.send(handle.FileDescriptor, &pinnedBuffer[offset], (IntPtr)size, GetPlatformSocketFlags(socketFlags));
+                    break;
                 }
             }
 
-            return sent;
+            bytesTransferred = bytesSent;
+            return errorCode;
         }
 
-        // TODO: refactor to accommodate GetLastSocketError
-        public static unsafe int SendTo(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, int peerAddressSize)
+        public static SocketError SendTo(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, int peerAddressSize, out int bytesTransferred)
         {
-            int sent;
-            fixed (byte* rawPeerAddress = peerAddress)
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            int bytesSent = 0;
+
+            SocketError errorCode;
+            while (!TryCompleteSendTo(fd, buffer, ref offset, ref size, platformFlags, peerAddress, peerAddressSize, ref bytesSent, out errorCode) && !handle.IsNonBlocking)
             {
-                Interop.libc.sockaddr* peerSockAddr = (Interop.libc.sockaddr*)rawPeerAddress;
-                if (buffer.Length == 0)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLOUT, out errorCode))
                 {
-                    sent = (int)Interop.libc.sendto(handle.FileDescriptor, null, IntPtr.Zero, GetPlatformSocketFlags(socketFlags), peerSockAddr, (uint)peerAddressSize);
-                }
-                else
-                {
-                    fixed (byte* pinnedBuffer = buffer)
-                    {
-                        sent = (int)Interop.libc.sendto(handle.FileDescriptor, &pinnedBuffer[offset], (IntPtr)size, GetPlatformSocketFlags(socketFlags), peerSockAddr, (uint)peerAddressSize);
-                    }
+                    break;
                 }
             }
 
-            return sent;
+            bytesTransferred = bytesSent;
+            return errorCode;
         }
 
-        public static unsafe SocketError Receive(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, ref SocketFlags socketFlags, out int bytesTransferred)
+        public static SocketError Receive(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, ref SocketFlags socketFlags, out int bytesTransferred)
         {
-            var iovecs = new Interop.libc.iovec[buffers.Count];
-            var handles = new GCHandle[buffers.Count];
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
 
-            try
+            int socketAddressLen = 0;
+            int bytesReceived;
+            int receiveFlags;
+            SocketError errorCode;
+            while (!TryCompleteReceiveFrom(fd, buffers, platformFlags, null, ref socketAddressLen, out bytesReceived, out receiveFlags, out errorCode) && !handle.IsNonBlocking)
             {
-                for (int i = 0; i < buffers.Count; i++)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLIN, out errorCode))
                 {
-                    handles[i] = GCHandle.Alloc(buffers[i].Array, GCHandleType.Pinned);
-                    iovecs[i].iov_base = &((byte*)handles[i].AddrOfPinnedObject())[buffers[i].Offset];
-                    iovecs[i].iov_len = (IntPtr)buffers[i].Count;
-                }
-
-                int received;
-                fixed (Interop.libc.iovec* iov = iovecs)
-                {
-                    var msghdr = new Interop.libc.msghdr(null, 0, iov, iovecs.Length, null, 0, 0);
-                    received = (int)Interop.libc.recvmsg(handle.FileDescriptor, &msghdr, GetPlatformSocketFlags(socketFlags));
-                }
-
-                if (received == -1)
-                {
-                    bytesTransferred = 0;
-                    return GetLastSocketError();
-                }
-
-                bytesTransferred = received;
-                return SocketError.Success;
-            }
-            finally
-            {
-                for (int i = 0; i < handles.Length; i++)
-                {
-                    if (handles[i].IsAllocated)
-                    {
-                        handles[i].Free();
-                    }
+                    break;
                 }
             }
+
+            socketFlags = GetSocketFlags(receiveFlags);
+            bytesTransferred = bytesReceived;
+            return errorCode;
         }
 
-        // TODO: refactor to accommodate GetLastSocketError
-        public static unsafe int Receive(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        public static SocketError Receive(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, out int bytesTransferred)
         {
-            int received;
-            if (buffer.Length == 0)
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            int socketAddressLen = 0;
+            int bytesReceived;
+            int receiveFlags;
+            SocketError errorCode;
+            while (!TryCompleteReceiveFrom(fd, buffer, offset, size, platformFlags, null, ref socketAddressLen, out bytesReceived, out receiveFlags, out errorCode) && !handle.IsNonBlocking)
             {
-                received = (int)Interop.libc.recv(handle.FileDescriptor, null, IntPtr.Zero, GetPlatformSocketFlags(socketFlags));
-            }
-            else
-            {
-                fixed (byte* pinnedBuffer = buffer)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLIN, out errorCode))
                 {
-                    received = (int)Interop.libc.recv(handle.FileDescriptor, &pinnedBuffer[offset], (IntPtr)size, GetPlatformSocketFlags(socketFlags));
+                    break;
                 }
             }
 
-            return received;
+            socketFlags = GetSocketFlags(receiveFlags);
+            bytesTransferred = bytesReceived;
+            return errorCode;
         }
 
-        public static unsafe SocketError ReceiveMessageFrom(Socket socket, SafeCloseSocket handle, byte[] buffer, int offset, int size, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
+        public static SocketError ReceiveMessageFrom(Socket socket, SafeCloseSocket handle, byte[] buffer, int offset, int size, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
         {
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+            byte[] socketAddressBuffer = socketAddress.Buffer;
+            int socketAddressLen = socketAddress.Size;
+
             bool isIPv4, isIPv6;
             Socket.GetIPProtocolInformation(socket.AddressFamily, socketAddress, out isIPv4, out isIPv6);
 
-            var pktinfoLen = isIPv4 ? sizeof(Interop.libc.in_pktinfo) : isIPv6 ? sizeof(Interop.libc.in6_pktinfo) : 0;
-            var cmsgBufferLen = Interop.libc.cmsghdr.Size + pktinfoLen;
-            var cmsgBuffer = stackalloc byte[cmsgBufferLen];
-
-            int received;
-            fixed (byte* peerAddress = socketAddress.Buffer)
-            fixed (byte* pinnedBuffer = buffer)
+            int bytesReceived;
+            int receiveFlags;
+            SocketError errorCode;
+            while (!TryCompleteReceiveMessageFrom(fd, buffer, offset, size, platformFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receiveFlags, out ipPacketInformation, out errorCode) && !handle.IsNonBlocking)
             {
-                var iovec = new Interop.libc.iovec {
-                    iov_base = &pinnedBuffer[offset],
-                    iov_len = (IntPtr)size
-                };
-
-                var msghdr = new Interop.libc.msghdr(peerAddress, (uint)socketAddress.Size, &iovec, 1, cmsgBuffer, cmsgBufferLen, 0);
-                received = (int)Interop.libc.recvmsg(handle.FileDescriptor, &msghdr, GetPlatformSocketFlags(socketFlags));
-                socketAddress.InternalSize = (int)msghdr.msg_namelen; // TODO: is this OK?
-                cmsgBufferLen = (int)msghdr.msg_controllen;
+                if (!Poll(fd, Interop.libc.PollFlags.POLLIN, out errorCode))
+                {
+                    break;
+                }
             }
 
+            socketAddress.InternalSize = socketAddressLen;
             receiveAddress = socketAddress;
-            ipPacketInformation = GetIPPacketInformation(cmsgBuffer, cmsgBufferLen, isIPv4, isIPv6);
-
-            if (received == -1)
-            {
-                bytesTransferred = 0;
-                return GetLastSocketError();
-            }
-
-            bytesTransferred = received;
-            return SocketError.Success;
+            socketFlags = GetSocketFlags(receiveFlags);
+            bytesTransferred = bytesReceived;
+            return errorCode;
         }
 
-        // TODO: refactor to accommodate GetLastSocketError
-        public static unsafe int ReceiveFrom(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, ref int addressLength)
+        public static SocketError ReceiveFrom(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, ref int addressLength, out int bytesTransferred)
         {
-            int received;
-            uint peerAddrLen = (uint)addressLength;
-            fixed (byte* rawPeerAddress = peerAddress)
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            int bytesReceived;
+            int receiveFlags;
+            SocketError errorCode;
+            while (!TryCompleteReceiveFrom(fd, buffer, offset, size, platformFlags, peerAddress, ref addressLength, out bytesReceived, out receiveFlags, out errorCode) && !handle.IsNonBlocking)
             {
-                Interop.libc.sockaddr* peerSockAddr = (Interop.libc.sockaddr*)rawPeerAddress;
-                if (buffer.Length == 0)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLIN, out errorCode))
                 {
-                    received = (int)Interop.libc.recvfrom(handle.FileDescriptor, null, IntPtr.Zero, GetPlatformSocketFlags(socketFlags), peerSockAddr, &peerAddrLen);
-                }
-                else
-                {
-                    fixed (byte* pinnedBuffer = buffer)
-                    {
-                        received = (int)Interop.libc.recvfrom(handle.FileDescriptor, &pinnedBuffer[offset], (IntPtr)size, GetPlatformSocketFlags(socketFlags), peerSockAddr, &peerAddrLen);
-                    }
+                    break;
                 }
             }
 
-            addressLength = (int)peerAddrLen;
-            return received;
+            bytesTransferred = bytesReceived;
+            return errorCode;
         }
 
         public static SocketError Ioctl(SafeCloseSocket handle, int ioControlCode, byte[] optionInValue, byte[] optionOutValue, out int optionLength)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -17,6 +17,8 @@ namespace System.Net.Sockets
 {
     internal static class SocketPal
     {
+        public const bool SupportsMultipleConnectAttempts = true;
+
         private readonly static int s_protocolInformationSize = Marshal.SizeOf<Interop.Winsock.WSAPROTOCOL_INFO>();
 
         public static int ProtocolInformationSize { get { return s_protocolInformationSize; } }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/_AcceptOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/_AcceptOverlappedAsyncResult.Unix.cs
@@ -32,12 +32,15 @@ namespace System.Net.Sockets
             _buffer = null;
             _localBytesTransferred = 0;
 
-            Internals.SocketAddress remoteSocketAddress = IPEndPointExtensions.Serialize(_listenSocket.m_RightEndPoint);
-            System.Buffer.BlockCopy(socketAddress, 0, remoteSocketAddress.Buffer, 0, socketAddressLen);
+			if (errorCode == SocketError.Success)
+			{
+				Internals.SocketAddress remoteSocketAddress = IPEndPointExtensions.Serialize(_listenSocket.m_RightEndPoint);
+				System.Buffer.BlockCopy(socketAddress, 0, remoteSocketAddress.Buffer, 0, socketAddressLen);
 
-            _acceptedSocket = _listenSocket.CreateAcceptSocket(
-                SafeCloseSocket.CreateSocket(acceptedFileDescriptor),
-                _listenSocket.m_RightEndPoint.Create(remoteSocketAddress));
+				_acceptedSocket = _listenSocket.CreateAcceptSocket(
+					SafeCloseSocket.CreateSocket(acceptedFileDescriptor),
+					_listenSocket.m_RightEndPoint.Create(remoteSocketAddress));
+			}
 
             base.CompletionCallback(0, errorCode);
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/_ConnectOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/_ConnectOverlappedAsyncResult.Unix.cs
@@ -27,7 +27,9 @@ namespace System.Net.Sockets
             var errorCode = (SocketError)ErrorCode;
             if (errorCode == SocketError.Success)
             {
-                return (Socket)AsyncObject;
+                var socket = (Socket)AsyncObject;
+                socket.SetToConnected();
+                return socket;
             }
 
             return null;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/_MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/_MultipleConnectAsync.cs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Disable CS0162: Unreachable code detected
+//
+// There is unreachable code in this file due to the use of SocketPal.SupportsMultipleConnectAttempts.
+#pragma warning disable 162
+
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,11 +23,14 @@ namespace System.Net.Sockets
         protected IPAddress[] addressList;
         protected int nextAddress;
 
+        private Socket _lastAttemptSocket;
+
         private enum State
         {
             NotStarted,
             DnsQuery,
             ConnectAttempt,
+            UserConnectAttempt,
             Completed,
             Canceled,
         }
@@ -30,6 +38,10 @@ namespace System.Net.Sockets
         private State _state;
 
         private object _lockObject = new object();
+
+        protected abstract bool RequiresUserConnectAttempt { get; }
+
+        protected abstract Socket UserSocket { get; }
 
         // Called by Socket to kick off the ConnectAsync process.  We'll complete the user's SAEA
         // when it's done.  Returns true if the operation will be asynchronous, false if it has failed synchronously
@@ -114,7 +126,11 @@ namespace System.Net.Sockets
 
                     internalArgs = new SocketAsyncEventArgs();
                     internalArgs.Completed += InternalConnectCallback;
-                    internalArgs.SetBuffer(userArgs.Buffer, userArgs.Offset, userArgs.Count);
+
+                    if (!RequiresUserConnectAttempt)
+                    {
+                        internalArgs.SetBuffer(userArgs.Buffer, userArgs.Offset, userArgs.Count);
+                    }
 
                     exception = AttemptConnection();
 
@@ -152,14 +168,25 @@ namespace System.Net.Sockets
                     // closed Socket.
                     exception = new SocketException((int)SocketError.OperationAborted);
                 }
-                else
+                else if (_state == State.ConnectAttempt)
                 {
-                    GlobalLog.Assert(_state == State.ConnectAttempt, "MultipleConnectAsync.InternalConnectCallback(): Unexpected object state");
-
                     if (args.SocketError == SocketError.Success)
                     {
-                        // the connection attempt succeeded; go to the completed state.
-                        // the callback will be called outside the lock
+                        if (RequiresUserConnectAttempt)
+                        {
+                            exception = AttemptUserConnection();
+
+                            if (exception == null)
+                            {
+                                // Don't call the callback; we've started a connection attempt on the
+                                // user's socket.
+                                _state = State.UserConnectAttempt;
+                                return;
+                            }
+                        }
+
+                        // The connection attempt succeeded or the user connect attempt failed synchronously; go to the
+                        // completed state. The callback will be called outside the lock.
                         _state = State.Completed;
                     }
                     else if (args.SocketError == SocketError.OperationAborted)
@@ -172,6 +199,13 @@ namespace System.Net.Sockets
                     else
                     {
                         // Try again, if there are more IPAddresses to be had.
+
+                        // If the underlying OS does not support multiple connect attempts
+                        // on the same socket, dispose the socket used for the last attempt.
+                        if (!SocketPal.SupportsMultipleConnectAttempts)
+                        {
+                            _lastAttemptSocket.Dispose();
+                        }
 
                         // Keep track of this because it will be overwritten by AttemptConnection
                         SocketError currentFailure = args.SocketError;
@@ -200,6 +234,28 @@ namespace System.Net.Sockets
                         }
                     }
                 }
+                else
+                {
+                    GlobalLog.Assert(_state == State.UserConnectAttempt, "MultipleConnectAsync.InternalConnectCallback(): Unexpected object state");
+                    GlobalLog.Assert(RequiresUserConnectAttempt, "MultipleConnectAsync.InternalConnectCallback(): State.UserConnectAttempt without RequiresUserConnectAttempt");
+
+                    if (args.SocketError == SocketError.Success)
+                    {
+                        _state = State.Completed;
+                    }
+                    else if (args.SocketError == SocketError.OperationAborted)
+                    {
+                        // The socket was closed while the connect was in progress.  This can happen if the user
+                        // closes the socket, and is equivalent to a call to CancelConnectAsync
+                        exception = new SocketException((int)SocketError.OperationAborted);
+                        _state = State.Canceled;
+                    }
+                    else
+                    {
+                        // The connect attempt on the user's socket failed. Return the corresponding error.
+                        exception = new SocketException((int)args.SocketError);
+                    }
+                }
             }
 
             if (exception == null)
@@ -218,21 +274,56 @@ namespace System.Net.Sockets
         {
             try
             {
-                Socket attemptSocket = null;
-                IPAddress attemptAddress = GetNextAddress(out attemptSocket);
+                IPAddress attemptAddress = GetNextAddress(out _lastAttemptSocket);
 
                 if (attemptAddress == null)
                 {
                     return new SocketException((int)SocketError.NoData);
                 }
 
-                GlobalLog.Assert(attemptSocket != null, "MultipleConnectAsync.AttemptConnection: attemptSocket is null!");
+                GlobalLog.Assert(attemptAddress != null, "MultipleConnectAsync.AttemptConnection: attemptAddress is null!");
 
                 internalArgs.RemoteEndPoint = new IPEndPoint(attemptAddress, endPoint.Port);
 
-                if (!attemptSocket.ConnectAsync(internalArgs))
+                return AttemptConnection(_lastAttemptSocket, internalArgs);
+            }
+            catch (Exception e)
+            {
+                GlobalLog.Assert(!(e is ObjectDisposedException), "MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                return e;
+            }
+        }
+
+        private Exception AttemptUserConnection()
+        {
+            Debug.Assert(!SocketPal.SupportsMultipleConnectAttempts);
+            Debug.Assert(_lastAttemptSocket != null);
+
+            try
+            {
+                _lastAttemptSocket.Dispose();
+
+                // Setup the internal args. RemoteEndpoint should already be correct.
+                internalArgs.SetBuffer(userArgs.Buffer, userArgs.Offset, userArgs.Count);
+
+                return AttemptConnection(UserSocket, internalArgs);
+            }
+            catch (Exception e)
+            {
+                GlobalLog.Assert(!(e is ObjectDisposedException), "MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                return e;
+            }
+        }
+
+        private static Exception AttemptConnection(Socket attemptSocket, SocketAsyncEventArgs args)
+        {
+            try
+            {
+                GlobalLog.Assert(attemptSocket != null, "MultipleConnectAsync.AttemptConnection: attemptSocket is null!");
+
+                if (!attemptSocket.ConnectAsync(args))
                 {
-                    return new SocketException((int)internalArgs.SocketError);
+                    return new SocketException((int)args.SocketError);
                 }
             }
             catch (ObjectDisposedException)
@@ -251,7 +342,7 @@ namespace System.Net.Sockets
 
         protected abstract void OnSucceed();
 
-        protected void Succeed()
+        private void Succeed()
         {
             OnSucceed();
             userArgs.FinishWrapperConnectSuccess(internalArgs.ConnectSocket, internalArgs.BytesTransferred, internalArgs.SocketFlags);
@@ -277,6 +368,11 @@ namespace System.Net.Sockets
         private void SyncFail(Exception e)
         {
             OnFail(false);
+
+            if (!SocketPal.SupportsMultipleConnectAttempts && _lastAttemptSocket != null)
+            {
+                _lastAttemptSocket.Dispose();
+            }
             if (internalArgs != null)
             {
                 internalArgs.Dispose();
@@ -296,6 +392,11 @@ namespace System.Net.Sockets
         private void AsyncFail(Exception e)
         {
             OnFail(false);
+
+            if (!SocketPal.SupportsMultipleConnectAttempts && _lastAttemptSocket != null)
+            {
+                _lastAttemptSocket.Dispose();
+            }
             if (internalArgs != null)
             {
                 internalArgs.Dispose();
@@ -330,10 +431,11 @@ namespace System.Net.Sockets
                             TaskCreationOptions.DenyChildAttach,
                             TaskScheduler.Default);
 
-                    callOnFail = true;
+                        callOnFail = true;
                         break;
 
                     case State.ConnectAttempt:
+                    case State.UserConnectAttempt:
                         // Cancel was called after the Dns query completed, but before we had a connection result to give
                         // to the user.  Closing the sockets will cause any in-progress ConnectAsync call to fail immediately
                         // with OperationAborted, and will cause ObjectDisposedException from any new calls to ConnectAsync
@@ -358,6 +460,11 @@ namespace System.Net.Sockets
             if (callOnFail)
             {
                 OnFail(true);
+
+                if (!SocketPal.SupportsMultipleConnectAttempts && _lastAttemptSocket != null)
+                {
+                    _lastAttemptSocket.Dispose();
+                }
             }
         }
 
@@ -373,10 +480,21 @@ namespace System.Net.Sockets
     // Used when the instance ConnectAsync method is called, or when the DnsEndPoint specified
     // an AddressFamily.  There's only one Socket, and we only try addresses that match its
     // AddressFamily
-    internal class SingleSocketMultipleConnectAsync : MultipleConnectAsync
+    internal sealed class SingleSocketMultipleConnectAsync : MultipleConnectAsync
     {
         private Socket _socket;
         private bool _userSocket;
+
+        protected override bool RequiresUserConnectAttempt { get { return !SocketPal.SupportsMultipleConnectAttempts; } }
+
+        protected override Socket UserSocket
+        {
+            get
+            {
+                Debug.Assert(!SocketPal.SupportsMultipleConnectAttempts);
+                return _socket;
+            }
+        }
 
         public SingleSocketMultipleConnectAsync(Socket socket, bool userSocket)
         {
@@ -386,13 +504,12 @@ namespace System.Net.Sockets
 
         protected override IPAddress GetNextAddress(out Socket attemptSocket)
         {
-            attemptSocket = _socket;
-
             IPAddress rval = null;
             do
             {
                 if (nextAddress >= addressList.Length)
                 {
+                    attemptSocket = null;
                     return null;
                 }
 
@@ -400,6 +517,19 @@ namespace System.Net.Sockets
                 ++nextAddress;
             }
             while (!_socket.CanTryAddressFamily(rval.AddressFamily));
+
+            if (SocketPal.SupportsMultipleConnectAttempts)
+            {
+                attemptSocket = _socket;
+            }
+            else
+            {
+                attemptSocket = new Socket(_socket.AddressFamily, _socket.SocketType, _socket.ProtocolType);
+                if (_socket.AddressFamily == AddressFamily.InterNetworkV6 && _socket.DualMode)
+                {
+                    attemptSocket.DualMode = true;
+                }
+            }
 
             return rval;
         }
@@ -420,13 +550,26 @@ namespace System.Net.Sockets
 
     // This is used when the static ConnectAsync method is called.  We don't know the address family
     // ahead of time, so we create both IPv4 and IPv6 sockets.
-    internal class MultipleSocketMultipleConnectAsync : MultipleConnectAsync
+    internal sealed class DualSocketMultipleConnectAsync : MultipleConnectAsync
     {
         private Socket _socket4;
         private Socket _socket6;
 
-        public MultipleSocketMultipleConnectAsync(SocketType socketType, ProtocolType protocolType)
+        protected override bool RequiresUserConnectAttempt { get { return false; } }
+
+        protected override Socket UserSocket
         {
+            get
+            {
+                Debug.Fail("Should never get here");
+                throw new NotImplementedException();
+            }
+        }
+
+        public DualSocketMultipleConnectAsync(SocketType socketType, ProtocolType protocolType)
+        {
+            Debug.Assert(SocketPal.SupportsMultipleConnectAttempts);
+
             if (Socket.OSSupportsIPv4)
             {
                 _socket4 = new Socket(AddressFamily.InterNetwork, socketType, protocolType);
@@ -490,5 +633,66 @@ namespace System.Net.Sockets
                 _socket6.Dispose();
             }
         }
+    }
+
+    internal sealed class MultipleSocketMultipleConnectAsync : MultipleConnectAsync
+    {
+        private readonly SocketType _socketType;
+        private readonly ProtocolType _protocolType;
+        private readonly bool _supportsIPv4;
+        private readonly bool _supportsIPv6;
+
+        protected override bool RequiresUserConnectAttempt { get { return false; } }
+
+        protected override Socket UserSocket
+        {
+            get
+            {
+                Debug.Fail("Should never get here");
+                throw new NotImplementedException();
+            }
+        }
+
+        public MultipleSocketMultipleConnectAsync(SocketType socketType, ProtocolType protocolType)
+        {
+            Debug.Assert(!SocketPal.SupportsMultipleConnectAttempts);
+
+            _socketType = socketType;
+            _protocolType = protocolType;
+            _supportsIPv4 = Socket.OSSupportsIPv4;
+            _supportsIPv6 = Socket.OSSupportsIPv6;
+        }
+
+        protected override IPAddress GetNextAddress(out Socket attemptSocket)
+        {
+            if (_supportsIPv4 || _supportsIPv6)
+            {
+                while (nextAddress < addressList.Length)
+                {
+                    IPAddress rval = addressList[nextAddress];
+                    ++nextAddress;
+
+                    if (_supportsIPv6 && rval.AddressFamily == AddressFamily.InterNetworkV6)
+                    {
+                        attemptSocket = new Socket(AddressFamily.InterNetworkV6, _socketType, _protocolType);
+                        return rval;
+                    }
+                    else if (_supportsIPv4 && rval.AddressFamily == AddressFamily.InterNetwork)
+                    {
+                        attemptSocket = new Socket(AddressFamily.InterNetwork, _socketType, _protocolType);
+                        return rval;
+                    }
+                }
+            }
+
+            attemptSocket = null;
+            return null;
+        }
+
+        // nothing to do on failure
+        protected override void OnFail(bool abortive) { }
+
+        // nothing to do on success
+        protected override void OnSucceed() { }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -8,8 +8,6 @@ namespace System.Net.Sockets.Tests
 {
     public class DnsEndPointTest
     {
-        private const int DummyIssue = 8000;
-
         private readonly ITestOutputHelper _log;
 
         public DnsEndPointTest(ITestOutputHelper output)
@@ -202,7 +200,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(DummyIssue, PlatformID.AnyUnix)]
         [Trait("IPv6", "true")]
         public void Socket_StaticConnectAsync_SyncFailure()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -8,6 +8,8 @@ namespace System.Net.Sockets.Tests
 {
     public class DnsEndPointTest
     {
+        private const int DummyIssue = 8000;
+
         private readonly ITestOutputHelper _log;
 
         public DnsEndPointTest(ITestOutputHelper output)
@@ -200,6 +202,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyIssue, PlatformID.AnyUnix)]
         [Trait("IPv6", "true")]
         public void Socket_StaticConnectAsync_SyncFailure()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -47,7 +47,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 12);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase);
             Assert.Throws<NotSupportedException>(() => {
                 socket.ConnectAsync(args);
             });
@@ -56,20 +56,20 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ConnectAsyncV4IPEndPointToV4Host_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 1);
         }
 
         [Fact]
         public void ConnectAsyncV6IPEndPointToV6Host_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 2);
         }
 
         [Fact]
         public void ConnectAsyncV4IPEndPointToV6Host_Fails()
         {
             Assert.Throws<SocketException>( () => {
-                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 3);
             });
         }
 
@@ -77,31 +77,31 @@ namespace System.Net.Sockets.Tests
         public void ConnectAsyncV6IPEndPointToV4Host_Fails()
         {
             Assert.Throws<SocketException> ( () => {
-                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 4);
             });
         }
 
         [Fact]
         public void ConnectAsyncV4IPEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 5);
         }
 
         [Fact]
         public void ConnectAsyncV6IPEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 6);
         }
 
-        private void DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
-            Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 13))
+            using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.Completed += new EventHandler<SocketAsyncEventArgs>(AsyncCompleted);
-                args.RemoteEndPoint = new IPEndPoint(connectTo, TestPortBase + 13);
+                args.RemoteEndPoint = new IPEndPoint(connectTo, port);
                 args.UserToken = waitHandle;
 
                 socket.ConnectAsync(args);
@@ -111,6 +111,7 @@ namespace System.Net.Sockets.Tests
                 {
                     throw new SocketException((int)args.SocketError);
                 }
+                Assert.True(server.WaitHandle.WaitOne(5000), "Timed out while waiting for accept");
                 Assert.True(socket.Connected);
             }
         }
@@ -122,35 +123,36 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToV4Host_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.Loopback, false);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.Loopback, false, TestPortBase + 10);
         }
 
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToV6Host_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false, TestPortBase + 11);
         }
 
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true, TestPortBase + 12);
         }
 
-        private void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer, int port)
         {
-            Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 51))
+            using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.Completed += new EventHandler<SocketAsyncEventArgs>(AsyncCompleted);
-                args.RemoteEndPoint = new DnsEndPoint("loopback", TestPortBase + 51);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", port);
                 args.UserToken = waitHandle;
 
                 socket.ConnectAsync(args);
 
                 waitHandle.WaitOne();
+                Assert.True(server.WaitHandle.WaitOne(5000), "Timed out while waiting for accept");
                 if (args.SocketError != SocketError.Success)
                 {
                     throw new SocketException((int)args.SocketError);
@@ -174,7 +176,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<SocketException>(() => {
                 using (Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 14));
+                    socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 20));
                 }
             });
         }
@@ -184,7 +186,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.Loopback.MapToIPv6(), TestPortBase + 15));
+                socket.Bind(new IPEndPoint(IPAddress.Loopback.MapToIPv6(), TestPortBase + 21));
             }
         }
 
@@ -193,7 +195,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 16));
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 22));
             }
         }
 
@@ -202,7 +204,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 17));
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 23));
             }
         }
 
@@ -212,7 +214,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<ArgumentException>(() => {
                 using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
                 {
-                    socket.Bind(new DnsEndPoint("loopback", TestPortBase + 52));
+                    socket.Bind(new DnsEndPoint("localhost", TestPortBase + 24));
                 }
             });
         }
@@ -224,32 +226,32 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void AcceptAsyncV4BoundToSpecificV4_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 41);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 30);
         }
 
         [Fact]
         public void AcceptAsyncV4BoundToAnyV4_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 42);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 31);
         }
 
         [Fact]
         public void AcceptAsyncV6BoundToSpecificV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 43);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 32);
         }
 
         [Fact]
         public void AcceptAsyncV6BoundToAnyV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 44);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 33);
         }
 
         [Fact]
         public void AcceptAsyncV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 45);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 34);
             });
         }
 
@@ -257,7 +259,7 @@ namespace System.Net.Sockets.Tests
         public void AcceptAsyncV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 46);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 35);
             });
         }
 
@@ -265,14 +267,14 @@ namespace System.Net.Sockets.Tests
         public void AcceptAsyncV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 47);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 36);
             });
         }
 
         [Fact]
         public void AcceptAsyncV4BoundToAnyV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 48);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 37);
         }
 
         private void DualModeConnect_AcceptAsync_Helper(IPAddress listenOn, IPAddress connectTo, int port)
@@ -334,6 +336,7 @@ namespace System.Net.Sockets.Tests
                 Assert.True(clientSocket.Connected);
                 Assert.Equal(AddressFamily.InterNetworkV6, clientSocket.AddressFamily);
                 Assert.Equal(connectTo.MapToIPv6(), ((IPEndPoint)clientSocket.LocalEndPoint).Address);
+                clientSocket.Dispose();
             }
         }
 
@@ -350,11 +353,11 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 25);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 40);
             args.SetBuffer(new byte[1], 0, 1);
             bool async = socket.SendToAsync(args);
             Assert.False(async);
-            Assert.Equal(SocketError.Fault, args.SocketError);
+			Assert.NotEqual(SocketError.Success, args.SocketError);
         }
 
         [Fact] // Base case
@@ -363,7 +366,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 53);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 41);
             args.SetBuffer(new byte[1], 0, 1);
             Assert.Throws<ArgumentException>(() => {
                 socket.SendToAsync(args);
@@ -373,20 +376,20 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void SendToAsyncV4IPEndPointToV4Host_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 42);
         }
 
         [Fact]
         public void SendToAsyncV6IPEndPointToV6Host_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 43);
         }
 
         [Fact]
         public void SendToAsyncV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 44);
             });
         }
 
@@ -394,30 +397,30 @@ namespace System.Net.Sockets.Tests
         public void SendToAsyncV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 45);
             });
         }
 
         [Fact]
         public void SendToAsyncV4IPEndPointToDualHost_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 46);
         }
 
         [Fact]
         public void SendToAsyncV6IPEndPointToDualHost_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 47);
         }
 
-        private void DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             ManualResetEvent waitHandle = new ManualResetEvent(false);
             Socket client = new Socket(SocketType.Dgram, ProtocolType.Udp);
-            using (SocketUdpServer server = new SocketUdpServer(_log, listenOn, dualModeServer, TestPortBase + 26))
+            using (SocketUdpServer server = new SocketUdpServer(_log, listenOn, dualModeServer, port))
             {
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(connectTo, TestPortBase + 26);
+                args.RemoteEndPoint = new IPEndPoint(connectTo, port);
                 args.SetBuffer(new byte[1], 0, 1);
                 args.UserToken = waitHandle;
                 args.Completed += AsyncCompleted;
@@ -451,7 +454,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 31);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 50);
             args.SetBuffer(new byte[1], 0, 1);
 
             Assert.Throws<ArgumentException>(() => {
@@ -465,9 +468,9 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 56));
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 51));
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 56, AddressFamily.InterNetworkV6);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 51, AddressFamily.InterNetworkV6);
                 args.SetBuffer(new byte[1], 0, 1);
 
                 Assert.Throws<ArgumentException>(() => {
@@ -479,32 +482,32 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ReceiveFromAsyncV4BoundToSpecificV4_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 52);
         }
 
         [Fact]
         public void ReceiveFromAsyncV4BoundToAnyV4_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 53);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToSpecificV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 54);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToAnyV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 55);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 56);
             });
         }
 
@@ -512,7 +515,7 @@ namespace System.Net.Sockets.Tests
         public void ReceiveFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 57);
             });
         }
 
@@ -520,31 +523,31 @@ namespace System.Net.Sockets.Tests
         public void ReceiveFromAsyncV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 58);
             });
         }
 
         [Fact]
         public void ReceiveFromAsyncV4BoundToAnyV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 59);
         }
 
-        private void ReceiveFromAsync_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void ReceiveFromAsync_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 32));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
 
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(listenOn, TestPortBase + 32);
+                args.RemoteEndPoint = new IPEndPoint(listenOn, port);
                 args.SetBuffer(new byte[1], 0, 1);
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 args.UserToken = waitHandle;
                 args.Completed += AsyncCompleted;
 
                 bool async = serverSocket.ReceiveFromAsync(args);
-                SocketUdpClient client = new SocketUdpClient(_log, serverSocket, connectTo, TestPortBase + 32);
+                SocketUdpClient client = new SocketUdpClient(_log, serverSocket, connectTo, port);
                 if (async && !waitHandle.WaitOne(200))
                 {
                     throw new TimeoutException();
@@ -588,6 +591,7 @@ namespace System.Net.Sockets.Tests
         {
             private readonly ITestOutputHelper _output;
             private Socket server;
+            private Socket accepted;
             private EventWaitHandle waitHandle = new AutoResetEvent(false);
 
             public EventWaitHandle WaitHandle
@@ -625,6 +629,7 @@ namespace System.Net.Sockets.Tests
                     "Accepted: " + e.GetHashCode() + " SocketAsyncEventArgs with manual event " +
                     handle.GetHashCode() + " error: " + e.SocketError);
 
+                accepted = e.AcceptSocket;
                 handle.Set();
             }
 
@@ -633,6 +638,10 @@ namespace System.Net.Sockets.Tests
                 try
                 {
                     server.Dispose();
+                    if (accepted != null)
+                    {
+                        accepted.Dispose();
+                    }
                 }
                 catch (Exception) { }
             }


### PR DESCRIPTION
With these changes, all of the Sockets tests except those that are (a) platform-specific, or (b) excluded due to differences in dual-stack semantics are passing on Linux.
