### PR TITLE
Fix *nix to match Winsock's separation of nonblocking/blocking and overlapped I/O. 

### DIFF
--- a/src/Common/src/Interop/Linux/libc/Interop.SocketFlags.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.SocketFlags.cs
@@ -10,5 +10,6 @@ internal static partial class Interop
         public const int MSG_DONTROUTE = 0x04; // Don't use local routing.
         public const int MSG_CTRUNC = 0x08;    // Control data lost before delivery.
         public const int MSG_TRUNC = 0x20;     // Data lost before delivery.
+        public const int MSG_DONTWAIT = 0x40;  // Use non-blocking I/O.
     }
 }

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -33,6 +33,8 @@ namespace System.Net.Sockets
         }
 
         public bool IsNonBlocking { get; set; }
+        public int ReceiveTimeout { get; set; }
+        public int SendTimeout { get; set; }
 
         public unsafe static SafeCloseSocket CreateSocket(int fileDescriptor)
         {
@@ -206,7 +208,7 @@ namespace System.Net.Sockets
                 SocketError errorCode;
                 while (!SocketPal.TryCompleteAccept(fd, socketAddress, ref socketAddressSize, out acceptedFd, out errorCode) && !socketHandle.IsNonBlocking)
                 {
-                    if (!SocketPal.Poll(fd, Interop.libc.PollFlags.POLLIN, out errorCode))
+                    if (!SocketPal.Poll(fd, Interop.libc.PollFlags.POLLIN, -1, out errorCode))
                     {
                         break;
                     }

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -230,7 +230,15 @@ namespace System.Net.Sockets
             public static unsafe InnerSafeCloseSocket Accept(SafeCloseSocket socketHandle, byte[] socketAddress, ref int socketAddressLen)
             {
                 int acceptedFd;
-                socketHandle.AsyncContext.Accept(socketAddress, ref socketAddressLen, -1, out acceptedFd);
+                if (!socketHandle.IsNonBlocking)
+                {
+                    socketHandle.AsyncContext.Accept(socketAddress, ref socketAddressLen, -1, out acceptedFd);
+                }
+                else
+                {
+                    SocketError unused;
+                    SocketPal.TryCompleteAccept(socketHandle.FileDescriptor, socketAddress, ref socketAddressLen, out acceptedFd, out unused);
+                }
 
                 var res = new InnerSafeCloseSocket();
                 res.SetHandle((IntPtr)acceptedFd);

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -300,6 +300,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.listen.cs">
       <Link>Interop\Unix\libc\Interop.listen.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.poll.cs">
+      <Link>Interop\Unix\libc\Interop.poll.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.recv.cs">
       <Link>Interop\Unix\libc\Interop.recv.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2205,35 +2205,33 @@ namespace System.Net.Sockets
             {
                 return getIPv6MulticastOpt(optionName);
             }
-            else
+
+            int optionValue = 0;
+
+            // This can throw ObjectDisposedException.
+            SocketError errorCode = SocketPal.GetSockOpt(
+                _handle,
+                optionLevel,
+                optionName,
+                out optionValue);
+
+            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+
+            //
+            // if the native call fails we'll throw a SocketException
+            //
+            if (errorCode != SocketError.Success)
             {
-                int optionValue = 0;
-
-                // This can throw ObjectDisposedException.
-                SocketError errorCode = SocketPal.GetSockOpt(
-                    _handle,
-                    optionLevel,
-                    optionName,
-                    out optionValue);
-
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
-
                 //
-                // if the native call fails we'll throw a SocketException
+                // update our internal state after this socket error and throw
                 //
-                if (errorCode != SocketError.Success)
-                {
-                    //
-                    // update our internal state after this socket error and throw
-                    //
-                    SocketException socketException = new SocketException((int)errorCode);
-                    UpdateStatusAfterSocketError(socketException);
-                    if (s_LoggingEnabled) Logging.Exception(Logging.Sockets, this, "GetSocketOption", socketException);
-                    throw socketException;
-                }
-
-                return optionValue;
+                SocketException socketException = new SocketException((int)errorCode);
+                UpdateStatusAfterSocketError(socketException);
+                if (s_LoggingEnabled) Logging.Exception(Logging.Sockets, this, "GetSocketOption", socketException);
+                throw socketException;
             }
+
+            return optionValue;
         }
 
         /// <devdoc>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1280,8 +1280,6 @@ namespace System.Net.Sockets
             //make sure we don't let the app mess up the buffer array enough to cause
             //corruption.
 
-            errorCode = SocketError.Success;
-
             int bytesTransferred;
             errorCode = SocketPal.Send(_handle, buffers, socketFlags, out bytesTransferred);
 
@@ -1368,17 +1366,17 @@ namespace System.Net.Sockets
             GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Send() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " size:" + size);
 
             // This can throw ObjectDisposedException.
-            int bytesTransferred = SocketPal.Send(_handle, buffer, offset, size, socketFlags);
+            int bytesTransferred;
+            errorCode = SocketPal.Send(_handle, buffer, offset, size, socketFlags, out bytesTransferred);
 
             //
             // if the native call fails we'll throw a SocketException
             //
-            if ((SocketError)bytesTransferred == SocketError.SocketError)
+            if (errorCode != SocketError.Success)
             {
                 //
                 // update our internal state after this socket error and throw
                 //
-                errorCode = SocketPal.GetLastSocketError();
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_LoggingEnabled)
                 {
@@ -1448,17 +1446,18 @@ namespace System.Net.Sockets
             Internals.SocketAddress socketAddress = CheckCacheRemote(ref endPointSnapshot, false);
 
             // This can throw ObjectDisposedException.
-            int bytesTransferred = SocketPal.SendTo(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, socketAddress.Size);
+            int bytesTransferred;
+            SocketError errorCode = SocketPal.SendTo(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, socketAddress.Size, out bytesTransferred);
 
             //
             // if the native call fails we'll throw a SocketException
             //
-            if ((SocketError)bytesTransferred == SocketError.SocketError)
+            if (errorCode != SocketError.Success)
             {
                 //
                 // update our internal state after this socket error and throw
                 //
-                SocketException socketException = new SocketException((int)SocketPal.GetLastSocketError());
+                SocketException socketException = new SocketException((int)errorCode);
                 UpdateStatusAfterSocketError(socketException);
                 if (s_LoggingEnabled) Logging.Exception(Logging.Sockets, this, "SendTo", socketException);
                 throw socketException;
@@ -1584,17 +1583,14 @@ namespace System.Net.Sockets
             ValidateBlockingMode();
             GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Receive() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " size:" + size);
 
-            // This can throw ObjectDisposedException.
-            errorCode = SocketError.Success;
+            int bytesTransferred;
+            errorCode = SocketPal.Receive(_handle, buffer, offset, size, socketFlags, out bytesTransferred);
 
-            int bytesTransferred = SocketPal.Receive(_handle, buffer, offset, size, socketFlags);
-
-            if ((SocketError)bytesTransferred == SocketError.SocketError)
+            if (errorCode != SocketError.Success)
             {
                 //
                 // update our internal state after this socket error and throw
                 //
-                errorCode = SocketPal.GetLastSocketError();
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_LoggingEnabled)
                 {
@@ -1879,14 +1875,15 @@ namespace System.Net.Sockets
             Internals.SocketAddress socketAddressOriginal = IPEndPointExtensions.Serialize(endPointSnapshot);
 
             // This can throw ObjectDisposedException.
-            int bytesTransferred = SocketPal.ReceiveFrom(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, ref socketAddress.InternalSize);
+            int bytesTransferred;
+            SocketError errorCode = SocketPal.ReceiveFrom(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, ref socketAddress.InternalSize, out bytesTransferred);
 
             // If the native call fails we'll throw a SocketException.
             // Must do this immediately after the native call so that the SocketException() constructor can pick up the error code.
             SocketException socketException = null;
-            if ((SocketError)bytesTransferred == SocketError.SocketError)
+            if (errorCode != SocketError.Success)
             {
-                socketException = new SocketException((int)SocketPal.GetLastSocketError());
+                socketException = new SocketException((int)errorCode);
                 UpdateStatusAfterSocketError(socketException);
                 if (s_LoggingEnabled) Logging.Exception(Logging.Sockets, this, "ReceiveFrom", socketException);
 
@@ -5581,7 +5578,8 @@ namespace System.Net.Sockets
                         }
                         else
                         {
-                            errorCode = (SocketError)SocketPal.Receive(_handle, null, 0, 0, SocketFlags.None);
+                            int unused;
+                            errorCode = SocketPal.Receive(_handle, null, 0, 0, SocketFlags.None, out unused);
                             GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") recv():" + errorCode.ToString());
 
                             if (errorCode != (SocketError)0)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -345,12 +345,8 @@ namespace System.Net.Sockets
             SocketAsyncEvents events = _registeredEvents & ~SocketAsyncEvents.Read;
 
             Interop.Error errorCode;
-            if (!_engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode))
-            {
-                // TODO: throw an appropiate exception
-                throw new Exception(string.Format("UnregisterRead: {0}", errorCode));
-            }
-
+            bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode);
+            Debug.Assert(unregistered, string.Format("UnregisterRead failed: {0}", errorCode));
             _registeredEvents = events;
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -95,6 +95,7 @@ namespace System.Net.Sockets
                     return true;
                 }
 
+                var spinWait = new SpinWait();
                 for (;;)
                 {
                     int state = Interlocked.CompareExchange(ref _state, (int)State.Cancelled, (int)State.Waiting);
@@ -102,6 +103,7 @@ namespace System.Net.Sockets
                     {
                         case State.Running:
                             // A completion attempt is in progress. Keep busy-waiting.
+                            spinWait.SpinOnce();
                             break;
 
                         case State.Complete:

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -20,17 +20,104 @@ namespace System.Net.Sockets
     {
         private abstract class AsyncOperation
         {
+            private enum State
+            {
+                Waiting = 0,
+                Running = 1,
+                Complete = 2,
+                Cancelled = 3
+            }
+
+            private int _state; // Actually AsyncOperation.State
+
             public AsyncOperation Next;
+            protected object CallbackOrEvent;
             public SocketError ErrorCode;
             public byte[] SocketAddress;
             public int SocketAddressLen;
 
+            public ManualResetEventSlim Event { set { CallbackOrEvent = value; } }
+
             public AsyncOperation()
             {
+                _state = (int)State.Waiting;
                 Next = this;
             }
 
-            public abstract void Complete();
+            public void QueueCompletionCallback()
+            {
+                Debug.Assert(!(CallbackOrEvent is ManualResetEventSlim));
+                Debug.Assert(_state != (int)State.Cancelled);
+
+                ThreadPool.QueueUserWorkItem(o => ((AsyncOperation)o).DoCallback(), this);
+            }
+
+            public bool TryComplete(int fileDescriptor)
+            {
+                Debug.Assert(_state == (int)State.Waiting);
+
+                return DoTryComplete(fileDescriptor);
+            }
+
+            public bool TryCompleteAsync(int fileDescriptor)
+            {
+                int state = Interlocked.CompareExchange(ref _state, (int)State.Running, (int)State.Waiting);
+                if (state == (int)State.Cancelled)
+                {
+                    // This operation has been cancelled.
+                    return true;
+                }
+                Debug.Assert(state != (int)State.Complete && state != (int)State.Running);
+
+                if (DoTryComplete(fileDescriptor))
+                {
+                    var @event = CallbackOrEvent as ManualResetEventSlim;
+                    if (@event != null)
+                    {
+                        @event.Set();
+                    }
+                    else
+                    {
+                        QueueCompletionCallback();
+                    }
+                    Volatile.Write(ref _state, (int)State.Complete);
+                    return true;
+                }
+
+                Volatile.Write(ref _state, (int)State.Waiting);
+                return false;
+            }
+
+            public bool Wait(int timeout)
+            {
+                if (((ManualResetEventSlim)CallbackOrEvent).Wait(timeout))
+                {
+                    return true;
+                }
+
+                for (;;)
+                {
+                    int state = Interlocked.CompareExchange(ref _state, (int)State.Cancelled, (int)State.Waiting);
+                    switch ((State)state)
+                    {
+                        case State.Running:
+                            // A completion attempt is in progress. Keep busy-waiting.
+                            break;
+
+                        case State.Complete:
+                            // A completion attempt succeeded. Consider this operation as having completed within the timeout.
+                            return true;
+
+                        case State.Waiting:
+                            // This operation was successfully cancelled.
+                            return false;
+                    }
+                }
+            }
+
+            protected abstract bool DoTryComplete(int fileDescriptor);
+
+            protected abstract void DoCallback();
         }
 
         private abstract class TransferOperation : AsyncOperation
@@ -43,32 +130,51 @@ namespace System.Net.Sockets
             public int ReceivedFlags;
         }
 
-        private sealed class SendReceiveOperation : TransferOperation
+        private abstract class SendReceiveOperation : TransferOperation
         {
-            public Action<int, byte[], int, int, SocketError> Callback;
+            public Action<int, byte[], int, int, SocketError> Callback { set { CallbackOrEvent = value; } }
             public BufferList Buffers;
             public int BufferIndex;
 
-            public override void Complete()
+            protected sealed override void DoCallback()
             {
-                Debug.Assert(Callback != null);
+                var callback = (Action<int, byte[], int, int, SocketError>)CallbackOrEvent;
+                callback(BytesTransferred, SocketAddress, SocketAddressLen, ReceivedFlags, ErrorCode);
+            }
+        }
 
-                Callback(BytesTransferred, SocketAddress, SocketAddressLen, ReceivedFlags, ErrorCode);
+        private sealed class SendOperation : SendReceiveOperation
+        {
+            protected override bool DoTryComplete(int fileDescriptor)
+            {
+                return SocketPal.TryCompleteSendTo(fileDescriptor, Buffer, Buffers, ref BufferIndex, ref Offset, ref Count, Flags, SocketAddress, SocketAddressLen, ref BytesTransferred, out ErrorCode);
+            }
+        }
+
+        private sealed class ReceiveOperation : SendReceiveOperation
+        {
+            protected override bool DoTryComplete(int fileDescriptor)
+            {
+                return SocketPal.TryCompleteReceiveFrom(fileDescriptor, Buffer, Buffers, Offset, Count, Flags, SocketAddress, ref SocketAddressLen, out BytesTransferred, out ReceivedFlags, out ErrorCode);
             }
         }
 
         private sealed class ReceiveMessageFromOperation : TransferOperation
         {
-            public Action<int, byte[], int, int, IPPacketInformation, SocketError> Callback;
+            public Action<int, byte[], int, int, IPPacketInformation, SocketError> Callback { set { CallbackOrEvent = value; } }
             public bool IsIPv4;
             public bool IsIPv6;
             public IPPacketInformation IPPacketInformation;
 
-            public override void Complete()
+            protected override bool DoTryComplete(int fileDescriptor)
             {
-                Debug.Assert(Callback != null);
+                return SocketPal.TryCompleteReceiveMessageFrom(fileDescriptor, Buffer, Offset, Count, Flags, SocketAddress, ref SocketAddressLen, IsIPv4, IsIPv6, out BytesTransferred, out ReceivedFlags, out IPPacketInformation, out ErrorCode);
+            }
 
-                Callback(BytesTransferred, SocketAddress, SocketAddressLen, ReceivedFlags, IPPacketInformation, ErrorCode);
+            protected override void DoCallback()
+            {
+                var callback = (Action<int, byte[], int, int, IPPacketInformation, SocketError>)CallbackOrEvent;
+                callback(BytesTransferred, SocketAddress, SocketAddressLen, ReceivedFlags, IPPacketInformation, ErrorCode);
             }
         }
 
@@ -78,34 +184,50 @@ namespace System.Net.Sockets
 
         private sealed class AcceptOperation : AcceptOrConnectOperation
         {
-            public Action<int, byte[], int, SocketError> Callback;
+            public Action<int, byte[], int, SocketError> Callback { set { CallbackOrEvent = value; } }
             public int AcceptedFileDescriptor;
 
-            public override void Complete()
+            protected override bool DoTryComplete(int fileDescriptor)
             {
-                Debug.Assert(Callback != null);
+                return SocketPal.TryCompleteAccept(fileDescriptor, SocketAddress, ref SocketAddressLen, out AcceptedFileDescriptor, out ErrorCode);
+            }
 
-                Callback(AcceptedFileDescriptor, SocketAddress, SocketAddressLen, ErrorCode);
+            protected override void DoCallback()
+            {
+                var callback = (Action<int, byte[], int, SocketError>)CallbackOrEvent;
+                callback(AcceptedFileDescriptor, SocketAddress, SocketAddressLen, ErrorCode);
             }
         }
 
         private sealed class ConnectOperation : AcceptOrConnectOperation
         {
-            public Action<SocketError> Callback;
+            public Action<SocketError> Callback { set { CallbackOrEvent = value; } }
 
-            public override void Complete()
+            protected override bool DoTryComplete(int fileDescriptor)
             {
-                Debug.Assert(Callback != null);
+                return SocketPal.TryCompleteConnect(fileDescriptor, SocketAddressLen, out ErrorCode);
 
-                Callback(ErrorCode);
+                // The only situation in which we should see EISCONN when completing an
+                // async connect is if this earlier connect completed successfully:
+                // POSIX does not allow more than one outstanding async connect.
+                // if (op.ErrorCode == SocketError.IsConnected)
+                // {
+                //     op.ErrorCode = SocketError.Success;
+                // }
+            }
+
+            protected override void DoCallback()
+            {
+                var callback = (Action<SocketError>)CallbackOrEvent;
+                callback(ErrorCode);
             }
         }
 
-        private enum State
+        private enum QueueState
         {
-            Stopped = -1,
             Clear = 0,
             Set = 1,
+            Stopped = 2,
         }
 
         private struct OperationQueue<TOperation>
@@ -113,8 +235,8 @@ namespace System.Net.Sockets
         {
             private AsyncOperation _tail;
 
-            public State State { get; set; }
-            public bool IsStopped { get { return State == State.Stopped; } }
+            public QueueState State { get; set; }
+            public bool IsStopped { get { return State == QueueState.Stopped; } }
             public bool IsEmpty { get { return _tail == null; } }
 
             public TOperation Head
@@ -169,7 +291,7 @@ namespace System.Net.Sockets
             {
                 OperationQueue<TOperation> result = this;
                 _tail = null;
-                State = State.Stopped;
+                State = QueueState.Stopped;
                 return result;
             }
         }
@@ -177,7 +299,7 @@ namespace System.Net.Sockets
         private int _fileDescriptor;
         private GCHandle _handle;
         private OperationQueue<TransferOperation> _receiveQueue;
-        private OperationQueue<SendReceiveOperation> _sendQueue;
+        private OperationQueue<SendOperation> _sendQueue;
         private OperationQueue<AcceptOrConnectOperation> _acceptOrConnectQueue;
         private SocketAsyncEngine _engine;
         private SocketAsyncEvents _registeredEvents;
@@ -246,66 +368,58 @@ namespace System.Net.Sockets
             bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, SocketAsyncEvents.None, _handle, out errorCode);
             _registeredEvents = (SocketAsyncEvents)(-1);
 
-			if (unregistered || errorCode == Interop.Error.EBADF)
-			{
-				_registeredEvents = SocketAsyncEvents.None;
-				_handle.Free();
-			}
+            if (unregistered || errorCode == Interop.Error.EBADF)
+            {
+                _registeredEvents = SocketAsyncEvents.None;
+                _handle.Free();
+            }
         }
 
         public void Close()
         {
             Debug.Assert(!Monitor.IsEntered(_queueLock));
 
-			OperationQueue<AcceptOrConnectOperation> acceptOrConnectQueue;
-			OperationQueue<SendReceiveOperation> sendQueue;
-			OperationQueue<TransferOperation> receiveQueue;
+            OperationQueue<AcceptOrConnectOperation> acceptOrConnectQueue;
+            OperationQueue<SendOperation> sendQueue;
+            OperationQueue<TransferOperation> receiveQueue;
 
             lock (_closeLock)
-			lock (_queueLock)
-			{
-				// Drain queues and unregister events
+            lock (_queueLock)
+            {
+                // Drain queues and unregister events
 
-				acceptOrConnectQueue = _acceptOrConnectQueue.Stop();
-				sendQueue = _sendQueue.Stop();
-				receiveQueue = _receiveQueue.Stop();
+                acceptOrConnectQueue = _acceptOrConnectQueue.Stop();
+                sendQueue = _sendQueue.Stop();
+                receiveQueue = _receiveQueue.Stop();
 
-				Unregister();
+                Unregister();
 
-				// TODO: assert that queues are all empty if _registeredEvents was SocketAsyncEvents.None?
-			}
+                // TODO: assert that queues are all empty if _registeredEvents was SocketAsyncEvents.None?
+            }
 
-			while (!acceptOrConnectQueue.IsEmpty)
-			{
-				AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
+            while (!acceptOrConnectQueue.IsEmpty)
+            {
+                AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
+                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                Debug.Assert(completed);
+                acceptOrConnectQueue.Dequeue();
+            }
 
-				var acceptOp = op as AcceptOperation;
-				bool completed = acceptOp != null ?
-					TryCompleteAccept(_fileDescriptor, acceptOp) :
-					TryCompleteConnect(_fileDescriptor, (ConnectOperation)op);
+            while (!sendQueue.IsEmpty)
+            {
+                SendReceiveOperation op = sendQueue.Head;
+                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                Debug.Assert(completed);
+                sendQueue.Dequeue();
+            }
 
-				Debug.Assert(completed);
-				acceptOrConnectQueue.Dequeue();
-				QueueCompletion(op);
-			}
-
-			while (!sendQueue.IsEmpty)
-			{
-				SendReceiveOperation op = sendQueue.Head;
-				bool completed = TryCompleteSendTo(_fileDescriptor, op);
-				Debug.Assert(completed);
-				sendQueue.Dequeue();
-				QueueCompletion(op);
-			}
-
-			while (!receiveQueue.IsEmpty)
-			{
-				TransferOperation op = receiveQueue.Head;
-				bool completed = TryCompleteReceive(_fileDescriptor, op);
-				Debug.Assert(completed);
-				receiveQueue.Dequeue();
-				QueueCompletion(op);
-			}
+            while (!receiveQueue.IsEmpty)
+            {
+                TransferOperation op = receiveQueue.Head;
+                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                Debug.Assert(completed);
+                receiveQueue.Dequeue();
+            }
         }
 
         private bool TryBeginOperation<TOperation>(ref OperationQueue<TOperation> queue, TOperation operation, out bool isStopped)
@@ -315,16 +429,16 @@ namespace System.Net.Sockets
             {
                 switch (queue.State)
                 {
-                    case State.Stopped:
+                    case QueueState.Stopped:
                         isStopped = true;
                         return false;
 
-                    case State.Clear:
+                    case QueueState.Clear:
                         break;
 
-                    case State.Set:
+                    case QueueState.Set:
                         isStopped = false;
-                        queue.State = State.Clear;
+                        queue.State = QueueState.Clear;
                         return false;
                 }
 
@@ -350,8 +464,60 @@ namespace System.Net.Sockets
             }
         }
 
+        public SocketError Accept(byte[] socketAddress, ref int socketAddressLen, int timeout, out int acceptedFd)
+        {
+            Debug.Assert(socketAddress != null);
+            Debug.Assert(socketAddressLen > 0);
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            SocketError errorCode;
+            if (SocketPal.TryCompleteAccept(_fileDescriptor, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode))
+            {
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new AcceptOperation {
+                    Event = @event,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error reasonable for a closed socket? Check with Winsock.
+                        acceptedFd = -1;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        socketAddressLen = operation.SocketAddressLen;
+                        acceptedFd = operation.AcceptedFileDescriptor;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                if (!operation.Wait(timeout))
+                {
+                    acceptedFd = -1;
+                    return SocketError.TimedOut;
+                }
+
+                socketAddressLen = operation.SocketAddressLen;
+                acceptedFd = operation.AcceptedFileDescriptor;
+                return operation.ErrorCode;
+            }
+        }
+
         public SocketError AcceptAsync(byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, SocketError> callback)
         {
+            Debug.Assert(socketAddress != null);
+            Debug.Assert(socketAddressLen > 0);
             Debug.Assert(callback != null);
 
             int acceptedFd;
@@ -382,22 +548,56 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteAccept(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
-        private static bool TryCompleteAccept(int fileDescriptor, AcceptOperation operation)
+        public SocketError Connect(byte[] socketAddress, int socketAddressLen, int timeout)
         {
-            return SocketPal.TryCompleteAccept(fileDescriptor, operation.SocketAddress, ref operation.SocketAddressLen, out operation.AcceptedFileDescriptor, out operation.ErrorCode);
+            Debug.Assert(socketAddress != null);
+            Debug.Assert(socketAddressLen > 0);
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            SocketError errorCode;
+            if (SocketPal.TryStartConnect(_fileDescriptor, socketAddress, socketAddressLen, out errorCode))
+            {
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new ConnectOperation {
+                    Event = @event,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error reasonable for a closed socket? Check with Winsock.
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        return operation.ErrorCode;
+                    }
+                }
+
+                return operation.Wait(timeout) ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError ConnectAsync(byte[] socketAddress, int socketAddressLen, Action<SocketError> callback)
@@ -429,27 +629,82 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteConnect(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
-        private static bool TryCompleteConnect(int fileDescriptor, ConnectOperation operation)
+        public SocketError Receive(byte[] buffer, int offset, int count, ref int flags, int timeout, out int bytesReceived)
         {
-            return SocketPal.TryCompleteConnect(fileDescriptor, operation.SocketAddressLen, out operation.ErrorCode);
+            int socketAddressLen = 0;
+            return ReceiveFrom(buffer, offset, count, ref flags, null, ref socketAddressLen, timeout, out bytesReceived);
         }
 
         public SocketError ReceiveAsync(byte[] buffer, int offset, int count, int flags, Action<int, byte[], int, int, SocketError> callback)
         {
             return ReceiveFromAsync(buffer, offset, count, flags, null, 0, callback);
+        }
+
+        public SocketError ReceiveFrom(byte[] buffer, int offset, int count, ref int flags, byte[] socketAddress, ref int socketAddressLen, int timeout, out int bytesReceived)
+        {
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            int receivedFlags;
+            SocketError errorCode;
+            if (SocketPal.TryCompleteReceiveFrom(_fileDescriptor, buffer, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+            {
+                flags = receivedFlags;
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new ReceiveOperation {
+                    Event = @event,
+                    Buffer = buffer,
+                    Offset = offset,
+                    Count = count,
+                    Flags = flags,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen,
+                    BytesTransferred = bytesReceived,
+                    ReceivedFlags = receivedFlags
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error code reasonable for a closed socket? Check with Winsock.
+                        flags = operation.ReceivedFlags;
+                        bytesReceived = operation.BytesTransferred;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        socketAddressLen = operation.SocketAddressLen;
+                        flags = operation.ReceivedFlags;
+                        bytesReceived = operation.BytesTransferred;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                bool signaled = operation.Wait(timeout);
+                socketAddressLen = operation.SocketAddressLen;
+                flags = operation.ReceivedFlags;
+                bytesReceived = operation.BytesTransferred;
+                return signaled ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError ReceiveFromAsync(byte[] buffer, int offset, int count, int flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, int, SocketError> callback)
@@ -470,7 +725,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            var operation = new SendReceiveOperation {
+            var operation = new ReceiveOperation {
                 Callback = callback,
                 Buffer = buffer,
                 Offset = offset,
@@ -489,22 +744,79 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteReceiveFrom(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
+        public SocketError Receive(IList<ArraySegment<byte>> buffers, ref int flags, int timeout, out int bytesReceived)
+        {
+            return ReceiveFrom(buffers, ref flags, null, 0, timeout, out bytesReceived);
+        }
+
         public SocketError ReceiveAsync(IList<ArraySegment<byte>> buffers, int flags, Action<int, byte[], int, int, SocketError> callback)
         {
             return ReceiveFromAsync(buffers, flags, null, 0, callback);
+        }
+
+        public SocketError ReceiveFrom(IList<ArraySegment<byte>> buffers, ref int flags, byte[] socketAddress, int socketAddressLen, int timeout, out int bytesReceived)
+        {
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            int receivedFlags;
+            SocketError errorCode;
+            if (SocketPal.TryCompleteReceiveFrom(_fileDescriptor, buffers, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+            {
+                flags = receivedFlags;
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new ReceiveOperation {
+                    Event = @event,
+                    Buffers = new BufferList(buffers),
+                    Flags = flags,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen,
+                    BytesTransferred = bytesReceived,
+                    ReceivedFlags = receivedFlags
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error code reasonable for a closed socket? Check with Winsock.
+                        flags = operation.ReceivedFlags;
+                        bytesReceived = operation.BytesTransferred;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        socketAddressLen = operation.SocketAddressLen;
+                        flags = operation.ReceivedFlags;
+                        bytesReceived = operation.BytesTransferred;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                bool signaled = operation.Wait(timeout);
+                socketAddressLen = operation.SocketAddressLen;
+                flags = operation.ReceivedFlags;
+                bytesReceived = operation.BytesTransferred;
+                return signaled ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError ReceiveFromAsync(IList<ArraySegment<byte>> buffers, int flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, int, SocketError> callback)
@@ -525,10 +837,12 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            var operation = new SendReceiveOperation {
+            var operation = new ReceiveOperation {
                 Callback = callback,
                 Buffers = new BufferList(buffers),
                 Flags = flags,
+                SocketAddress = socketAddress,
+                SocketAddressLen = socketAddressLen,
                 BytesTransferred = bytesReceived,
                 ReceivedFlags = receivedFlags
             };
@@ -540,22 +854,78 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteReceiveFrom(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
-        private static bool TryCompleteReceiveFrom(int fileDescriptor, SendReceiveOperation operation)
+        public SocketError ReceiveMessageFrom(byte[] buffer, int offset, int count, ref int flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, int timeout, out IPPacketInformation ipPacketInformation, out int bytesReceived)
         {
-            return SocketPal.TryCompleteReceiveFrom(fileDescriptor, operation.Buffer, operation.Buffers, operation.Offset, operation.Count, operation.Flags, operation.SocketAddress, ref operation.SocketAddressLen, out operation.BytesTransferred, out operation.ReceivedFlags, out operation.ErrorCode);
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            int receivedFlags;
+            SocketError errorCode;
+            if (SocketPal.TryCompleteReceiveMessageFrom(_fileDescriptor, buffer, offset, count, flags, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, out errorCode))
+            {
+                flags = receivedFlags;
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new ReceiveMessageFromOperation {
+                    Event = @event,
+                    Buffer = buffer,
+                    Offset = offset,
+                    Count = count,
+                    Flags = flags,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen,
+                    IsIPv4 = isIPv4,
+                    IsIPv6 = isIPv6,
+                    BytesTransferred = bytesReceived,
+                    ReceivedFlags = receivedFlags,
+                    IPPacketInformation = ipPacketInformation,
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error code reasonable for a closed socket? Check with Winsock.
+                        socketAddressLen = operation.SocketAddressLen;
+                        flags = operation.ReceivedFlags;
+                        ipPacketInformation = operation.IPPacketInformation;
+                        bytesReceived = operation.BytesTransferred;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        socketAddressLen = operation.SocketAddressLen;
+                        flags = operation.ReceivedFlags;
+                        ipPacketInformation = operation.IPPacketInformation;
+                        bytesReceived = operation.BytesTransferred;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                bool signaled = operation.Wait(timeout);
+                socketAddressLen = operation.SocketAddressLen;
+                flags = operation.ReceivedFlags;
+                ipPacketInformation = operation.IPPacketInformation;
+                bytesReceived = operation.BytesTransferred;
+                return signaled ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError ReceiveMessageFromAsync(byte[] buffer, int offset, int count, int flags, byte[] socketAddress, int socketAddressLen, bool isIPv4, bool isIPv6, Action<int, byte[], int, int, IPPacketInformation, SocketError> callback)
@@ -599,38 +969,74 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteReceiveMessageFrom(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
-        private static bool TryCompleteReceiveMessageFrom(int fileDescriptor, ReceiveMessageFromOperation operation)
+        public SocketError Send(byte[] buffer, int offset, int count, int flags, int timeout, out int bytesSent)
         {
-            return SocketPal.TryCompleteReceiveMessageFrom(fileDescriptor, operation.Buffer, operation.Offset, operation.Count, operation.Flags, operation.SocketAddress, ref operation.SocketAddressLen, operation.IsIPv4, operation.IsIPv6, out operation.BytesTransferred, out operation.ReceivedFlags, out operation.IPPacketInformation, out operation.ErrorCode);
-        }
-
-        private static bool TryCompleteReceive(int fileDescriptor, TransferOperation operation)
-        {
-            var sendReceiveOperation = operation as SendReceiveOperation;
-            if (sendReceiveOperation != null)
-            {
-                return TryCompleteReceiveFrom(fileDescriptor, sendReceiveOperation);
-            }
-
-            return TryCompleteReceiveMessageFrom(fileDescriptor, (ReceiveMessageFromOperation)operation);
+            return SendTo(buffer, offset, count, flags, null, 0, timeout, out bytesSent);
         }
 
         public SocketError SendAsync(byte[] buffer, int offset, int count, int flags, Action<int, byte[], int, int, SocketError> callback)
         {
             return SendToAsync(buffer, offset, count, flags, null, 0, callback);
+        }
+
+        public SocketError SendTo(byte[] buffer, int offset, int count, int flags, byte[] socketAddress, int socketAddressLen, int timeout, out int bytesSent)
+        {
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            bytesSent = 0;
+            SocketError errorCode;
+            if (SocketPal.TryCompleteSendTo(_fileDescriptor, buffer, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+            {
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new SendOperation {
+                    Event = @event,
+                    Buffer = buffer,
+                    Offset = offset,
+                    Count = count,
+                    Flags = flags,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen,
+                    BytesTransferred = bytesSent
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _sendQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error code reasonable for a closed socket? Check with Winsock.
+                        bytesSent = operation.BytesTransferred;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        bytesSent = operation.BytesTransferred;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                bool signaled = operation.Wait(timeout);
+                bytesSent = operation.BytesTransferred;
+                return signaled ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError SendToAsync(byte[] buffer, int offset, int count, int flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, int, SocketError> callback)
@@ -650,7 +1056,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            var operation = new SendReceiveOperation {
+            var operation = new SendOperation {
                 Callback = callback,
                 Buffer = buffer,
                 Offset = offset,
@@ -668,22 +1074,76 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteSendTo(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
         }
 
+        public SocketError Send(BufferList buffers, int flags, int timeout, out int bytesSent)
+        {
+            return SendTo(buffers, flags, null, 0, timeout, out bytesSent);
+        }
+
         public SocketError SendAsync(BufferList buffers, int flags, Action<int, byte[], int, int, SocketError> callback)
         {
             return SendToAsync(buffers, flags, null, 0, callback);
+        }
+
+        public SocketError SendTo(BufferList buffers, int flags, byte[] socketAddress, int socketAddressLen, int timeout, out int bytesSent)
+        {
+            Debug.Assert(timeout == -1 || timeout > 0);
+
+            bytesSent = 0;
+            int bufferIndex = 0;
+            int offset = 0;
+            SocketError errorCode;
+            if (SocketPal.TryCompleteSendTo(_fileDescriptor, buffers, ref bufferIndex, ref offset, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+            {
+                return errorCode;
+            }
+
+            using (var @event = new ManualResetEventSlim())
+            {
+                var operation = new SendOperation {
+                    Event = @event,
+                    Buffers = buffers,
+                    BufferIndex = bufferIndex,
+                    Offset = offset,
+                    Flags = flags,
+                    SocketAddress = socketAddress,
+                    SocketAddressLen = socketAddressLen,
+                    BytesTransferred = bytesSent
+                };
+
+                bool isStopped;
+                while (!TryBeginOperation(ref _sendQueue, operation, out isStopped))
+                {
+                    if (isStopped)
+                    {
+                        // TODO: is this error code reasonable for a closed socket? Check with Winsock.
+                        bytesSent = operation.BytesTransferred;
+                        return SocketError.Shutdown;
+                    }
+
+                    if (operation.TryComplete(_fileDescriptor))
+                    {
+                        bytesSent = operation.BytesTransferred;
+                        return operation.ErrorCode;
+                    }
+                }
+
+                bool signaled = operation.Wait(timeout);
+                bytesSent = operation.BytesTransferred;
+                return signaled ? operation.ErrorCode : SocketError.TimedOut;
+            }
         }
 
         public SocketError SendToAsync(BufferList buffers, int flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, int, SocketError> callback)
@@ -705,7 +1165,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            var operation = new SendReceiveOperation {
+            var operation = new SendOperation {
                 Callback = callback,
                 Buffers = buffers,
                 BufferIndex = bufferIndex,
@@ -723,27 +1183,17 @@ namespace System.Net.Sockets
                 {
                     // TODO: is this error code reasonable for a closed socket? Check with Winsock.
                     operation.ErrorCode = SocketError.Shutdown;
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     return SocketError.Shutdown;
                 }
 
-                if (TryCompleteSendTo(_fileDescriptor, operation))
+                if (operation.TryComplete(_fileDescriptor))
                 {
-                    QueueCompletion(operation);
+                    operation.QueueCompletionCallback();
                     break;
                 }
             }
             return SocketError.IOPending;
-        }
-
-        private static bool TryCompleteSendTo(int fileDescriptor, SendReceiveOperation operation)
-        {
-            return SocketPal.TryCompleteSendTo(fileDescriptor, operation.Buffer, operation.Buffers, ref operation.BufferIndex, ref operation.Offset, ref operation.Count, operation.Flags, operation.SocketAddress, operation.SocketAddressLen, ref operation.BytesTransferred, out operation.ErrorCode);
-        }
-
-        private static void QueueCompletion(AsyncOperation operation)
-        {
-            ThreadPool.QueueUserWorkItem(o => ((AsyncOperation)o).Complete(), operation);
         }
 
         public unsafe void HandleEvents(SocketAsyncEvents events)
@@ -769,9 +1219,9 @@ namespace System.Net.Sockets
 
                 if ((events & SocketAsyncEvents.Error) != 0)
                 {
-					// We should only receive error events in conjuntction with other events.
-					// Processing for those events will pick up the error.
-					Debug.Assert((events & ~SocketAsyncEvents.Error) != 0);
+                    // We should only receive error events in conjuntction with other events.
+                    // Processing for those events will pick up the error.
+                    Debug.Assert((events & ~SocketAsyncEvents.Error) != 0);
                 }
 
                 if ((events & SocketAsyncEvents.ReadClose) != 0)
@@ -788,10 +1238,9 @@ namespace System.Net.Sockets
                     while (!receiveQueue.IsEmpty)
                     {
                         TransferOperation op = receiveQueue.Head;
-                        bool completed = TryCompleteReceive(_fileDescriptor, op);
+                        bool completed = op.TryCompleteAsync(_fileDescriptor);
                         Debug.Assert(completed);
                         receiveQueue.Dequeue();
-                        QueueCompletion(op);
                     }
 
                     lock (_queueLock)
@@ -814,24 +1263,23 @@ namespace System.Net.Sockets
                     lock (_queueLock)
                     {
                         acceptTail = _acceptOrConnectQueue.Tail as AcceptOperation;
-						_acceptOrConnectQueue.State = State.Set;
+                        _acceptOrConnectQueue.State = QueueState.Set;
 
                         receiveTail = _receiveQueue.Tail;
-                        _receiveQueue.State = State.Set;
+                        _receiveQueue.State = QueueState.Set;
                     }
 
                     if (acceptTail != null)
                     {
-                        AcceptOperation op;
+                        AcceptOrConnectOperation op;
                         do
                         {
-                            op = (AcceptOperation)_acceptOrConnectQueue.Head;
-                            if (TryCompleteAccept(_fileDescriptor, op))
+                            op = _acceptOrConnectQueue.Head;
+                            if (!op.TryCompleteAsync(_fileDescriptor))
                             {
-                                EndOperation(ref _acceptOrConnectQueue);
-                                QueueCompletion(op);
+                                break;
                             }
-                            break;
+                            EndOperation(ref _acceptOrConnectQueue);
                         } while (op != acceptTail);
                     }
 
@@ -841,12 +1289,11 @@ namespace System.Net.Sockets
                         do
                         {
                             op = _receiveQueue.Head;
-                            if (TryCompleteReceive(_fileDescriptor, op))
+                            if (!op.TryCompleteAsync(_fileDescriptor))
                             {
-                                EndOperation(ref _receiveQueue);
-                                QueueCompletion(op);
+                                break;
                             }
-                            break;
+                            EndOperation(ref _receiveQueue);
                         } while (op != receiveTail);
                     }
                 }
@@ -854,51 +1301,41 @@ namespace System.Net.Sockets
                 if ((events & SocketAsyncEvents.Write) != 0)
                 {
                     AcceptOrConnectOperation connectTail;
-                    SendReceiveOperation sendTail;
+                    SendOperation sendTail;
                     lock (_queueLock)
                     {
                         connectTail = _acceptOrConnectQueue.Tail as ConnectOperation;
-                        _acceptOrConnectQueue.State = State.Set;
+                        _acceptOrConnectQueue.State = QueueState.Set;
 
                         sendTail = _sendQueue.Tail;
-                        _sendQueue.State = State.Set;
+                        _sendQueue.State = QueueState.Set;
                     }
 
                     if (connectTail != null)
                     {
-                        ConnectOperation op;
+                        AcceptOrConnectOperation op;
                         do
                         {
-                            op = (ConnectOperation)_acceptOrConnectQueue.Head;
-                            if (TryCompleteConnect(_fileDescriptor, op))
+                            op = _acceptOrConnectQueue.Head;
+                            if (!op.TryCompleteAsync(_fileDescriptor))
                             {
-                                EndOperation(ref _acceptOrConnectQueue);
-
-                                // The only situation in which we should see EISCONN when completing an
-                                // async connect is if this earlier connect completed successfully:
-                                // POSIX does not allow more than one outstanding async connect.
-                                if (op.ErrorCode == SocketError.IsConnected)
-                                {
-                                    op.ErrorCode = SocketError.Success;
-                                }
-                                QueueCompletion(op);
+                                break;
                             }
-                            break;
+                            EndOperation(ref _acceptOrConnectQueue);
                         } while (op != connectTail);
                     }
 
                     if (sendTail != null)
                     {
-                        SendReceiveOperation op;
+                        SendOperation op;
                         do
                         {
                             op = _sendQueue.Head;
-                            if (TryCompleteSendTo(_fileDescriptor, op))
+                            if (!op.TryCompleteAsync(_fileDescriptor))
                             {
-                                EndOperation(ref _sendQueue);
-                                QueueCompletion(op);
+                                break;
                             }
-                            break;
+                            EndOperation(ref _sendQueue);
                         } while (op != sendTail);
                     }
                 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -47,7 +47,7 @@ namespace System.Net.Sockets
                                     }
                                     catch (Exception e)
                                     {
-                                        Debug.Fail("Exception thrown from event loop: {0}", e.Message);
+                                        Debug.Fail(string.Format("Exception thrown from event loop: {0}", e.Message));
                                     }
                                 }
                             }, engine, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -38,12 +38,14 @@ namespace System.Net.Sockets
                         if (_engine == null)
                         {
                             var engine = new SocketAsyncEngine(SocketAsyncEngineBackend.Create());
-                            Task.Factory.StartNew(o => {
+                            Task.Factory.StartNew(o =>
+                            {
+                                SocketAsyncEngineBackend backend = ((SocketAsyncEngine)o)._backend;
                                 for (;;)
                                 {
                                     try
                                     {
-                                        ((SocketAsyncEngine)o)._backend.EventLoop();
+                                        backend.EventLoop();
                                     }
                                     catch (Exception e)
                                     {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -39,7 +39,17 @@ namespace System.Net.Sockets
                         {
                             var engine = new SocketAsyncEngine(SocketAsyncEngineBackend.Create());
                             Task.Factory.StartNew(o => {
-                                ((SocketAsyncEngine)o)._backend.EventLoop();
+                                for (;;)
+                                {
+                                    try
+                                    {
+                                        ((SocketAsyncEngine)o)._backend.EventLoop();
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        Debug.Fail("Exception thrown from event loop: {0}", e.Message);
+                                    }
+                                }
                             }, engine, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
                             Volatile.Write(ref _engine, engine);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -275,8 +275,7 @@ namespace System.Net.Sockets
 
         private unsafe void FinishOperationReceiveMessageFrom()
         {
-            // TODO: implement this.
-            throw new NotImplementedException();
+            // No-op for *nix.
         }
 
         private void FinishOperationSendPackets()

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -530,16 +530,596 @@ namespace System.Net.Sockets
             throw new PlatformNotSupportedException();
         }
 
-        public static SocketError SetBlocking(SafeCloseSocket handle, bool shouldBlock, out bool willBlock)
+        public static unsafe bool Poll(int fd, Interop.libc.PollFlags events, out SocketError errorCode)
         {
-            int err = Interop.Sys.Fcntl.SetIsNonBlocking(handle.FileDescriptor, shouldBlock ? 0 : 1);
-            if (err == -1)
+            // TODO: respect send/receive timeouts?
+
+            var pollfd = new Interop.libc.pollfd {
+                fd = fd,
+                events = events
+            };
+
+            int nfds = Interop.libc.poll(&pollfd, 1, -1);
+            if (nfds != 1)
             {
-                // TODO: consider this value
-                willBlock = shouldBlock;
-                return GetLastSocketError();
+                errorCode = nfds == 0 ? SocketError.SocketError : GetLastSocketError();
+                return false;
             }
 
+            if ((pollfd.revents & events) == 0)
+            {
+                errorCode = SocketError.SocketError;
+                return false;
+            }
+
+            errorCode = SocketError.Success;
+            return true;
+        }
+
+        private static unsafe int Receive(int fd, int flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, out int receivedFlags, out Interop.Error errno)
+        {
+            Debug.Assert(socketAddress != null || socketAddressLen == 0);
+
+            var pinnedSocketAddress = default(GCHandle);
+            Interop.libc.sockaddr* sockAddr = null;
+            uint sockAddrLen = 0;
+
+            int received;
+            try
+            {
+                if (socketAddress != null)
+                {
+                    pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
+                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddrLen = (uint)socketAddressLen;
+                }
+
+                fixed (byte* b = buffer)
+                {
+                    var iov = new Interop.libc.iovec {
+                        iov_base = &b[offset],
+                        iov_len = (IntPtr)count
+                    };
+
+                    var msghdr = new Interop.libc.msghdr(sockAddr, sockAddrLen, &iov, 1, null, 0, 0);
+                    received = (int)Interop.libc.recvmsg(fd, &msghdr, flags);
+                    receivedFlags = msghdr.msg_flags;
+                    sockAddrLen = msghdr.msg_namelen;
+                }
+            }
+            finally
+            {
+                if (pinnedSocketAddress.IsAllocated)
+                {
+                    pinnedSocketAddress.Free();
+                }
+            }
+
+            if (received == -1)
+            {
+                errno = Interop.Sys.GetLastError();
+                return -1;
+            }
+
+            socketAddressLen = (int)sockAddrLen;
+            errno = Interop.Error.SUCCESS;
+            return received;
+        }
+
+        private static unsafe int Send(int fd, int flags, byte[] buffer, ref int offset, ref int count, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
+        {
+            var pinnedSocketAddress = default(GCHandle);
+            Interop.libc.sockaddr* sockAddr = null;
+            uint sockAddrLen = 0;
+
+            int sent;
+            try
+            {
+                if (socketAddress != null)
+                {
+                    pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
+                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddrLen = (uint)socketAddressLen;
+                }
+
+                fixed (byte* b = buffer)
+                {
+                    sent = (int)Interop.libc.sendto(fd, &b[offset], (IntPtr)count, flags, sockAddr, sockAddrLen);
+                }
+            }
+            finally
+            {
+                if (pinnedSocketAddress.IsAllocated)
+                {
+                    pinnedSocketAddress.Free();
+                }
+            }
+
+            if (sent == -1)
+            {
+                errno = Interop.Sys.GetLastError();
+                return -1;
+            }
+
+            errno = Interop.Error.SUCCESS;
+            offset += sent;
+            count -= sent;
+            return sent;
+        }
+
+        private static unsafe int Send(int fd, int flags, BufferList buffers, ref int bufferIndex, ref int offset, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
+        {
+            // Pin buffers and set up iovecs
+            int startIndex = bufferIndex, startOffset = offset;
+
+            var pinnedSocketAddress = default(GCHandle);
+            Interop.libc.sockaddr* sockAddr = null;
+            uint sockAddrLen = 0;
+
+            int maxBuffers = buffers.Count - startIndex;
+            var handles = new GCHandle[maxBuffers];
+            var iovecs = new Interop.libc.iovec[maxBuffers];
+
+            int sent;
+            int toSend = 0, iovCount = maxBuffers;
+            try
+            {
+                for (int i = 0; i < maxBuffers; i++, startOffset = 0)
+                {
+                    ArraySegment<byte> buffer = buffers[startIndex + i];
+                    Debug.Assert(buffer.Offset + startOffset < buffer.Array.Length);
+
+                    handles[i] = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
+                    iovecs[i].iov_base = &((byte*)handles[i].AddrOfPinnedObject())[buffer.Offset + startOffset];
+
+                    toSend += (buffer.Count - startOffset);
+                    iovecs[i].iov_len = (IntPtr)(buffer.Count - startOffset);
+                }
+
+                if (socketAddress != null)
+                {
+                    pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
+                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddrLen = (uint)socketAddressLen;
+                }
+
+                // Make the call
+                fixed (Interop.libc.iovec* iov = iovecs)
+                {
+                    var msghdr = new Interop.libc.msghdr(sockAddr, sockAddrLen, iov, iovCount, null, 0, 0);
+                    sent = (int)Interop.libc.sendmsg(fd, &msghdr, flags);
+                }
+                errno = Interop.Sys.GetLastError();
+            }
+            finally
+            {
+                // Free GC handles
+                for (int i = 0; i < iovCount; i++)
+                {
+                    if (handles[i].IsAllocated)
+                    {
+                        handles[i].Free();
+                    }
+                }
+
+                if (pinnedSocketAddress.IsAllocated)
+                {
+                    pinnedSocketAddress.Free();
+                }
+            }
+
+            if (sent == -1)
+            {
+                return -1;
+            }
+
+            // Update position
+            int endIndex = bufferIndex, endOffset = offset, unconsumed = sent;
+            for (; endIndex < buffers.Count && unconsumed > 0; endIndex++, endOffset = 0)
+            {
+                int space = buffers[endIndex].Count - endOffset;
+                if (space > unconsumed)
+                {
+                    endOffset += unconsumed;
+                    break;
+                }
+                unconsumed -= space;
+            }
+
+            bufferIndex = endIndex;
+            offset = endOffset;
+
+            return sent;
+        }
+
+        private static unsafe int Receive(int fd, int flags, int available, BufferList buffers, byte[] socketAddress, ref int socketAddressLen, out int receivedFlags, out Interop.Error errno)
+        {
+            // Pin buffers and set up iovecs
+            int maxBuffers = buffers.Count;
+            var handles = new GCHandle[maxBuffers];
+            var iovecs = new Interop.libc.iovec[maxBuffers];
+
+            var pinnedSocketAddress = default(GCHandle);
+            Interop.libc.sockaddr* sockAddr = null;
+            uint sockAddrLen = 0;
+
+            int received = 0;
+            int toReceive = 0, iovCount = maxBuffers;
+            try
+            {
+                for (int i = 0; i < maxBuffers; i++)
+                {
+                    ArraySegment<byte> buffer = buffers[i];
+                    handles[i] = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
+                    iovecs[i].iov_base = &((byte*)handles[i].AddrOfPinnedObject())[buffer.Offset];
+
+                    int space = buffer.Count;
+                    toReceive += space;
+                    if (toReceive >= available)
+                    {
+                        iovecs[i].iov_len = (IntPtr)(space - (toReceive - available));
+                        toReceive = available;
+                        iovCount = i + 1;
+                        break;
+                    }
+
+                    iovecs[i].iov_len = (IntPtr)space;
+                }
+
+                if (socketAddress != null)
+                {
+                    pinnedSocketAddress = GCHandle.Alloc(socketAddress, GCHandleType.Pinned);
+                    sockAddr = (Interop.libc.sockaddr*)pinnedSocketAddress.AddrOfPinnedObject();
+                    sockAddrLen = (uint)socketAddressLen;
+                }
+
+                // Make the call
+                fixed (Interop.libc.iovec* iov = iovecs)
+                {
+                    var msghdr = new Interop.libc.msghdr(sockAddr, sockAddrLen, iov, iovCount, null, 0, 0);
+                    received = (int)Interop.libc.recvmsg(fd, &msghdr, flags);
+                    receivedFlags = msghdr.msg_flags;
+                    sockAddrLen = msghdr.msg_namelen;
+                }
+            }
+            finally
+            {
+                // Free GC handles
+                for (int i = 0; i < iovCount; i++)
+                {
+                    if (handles[i].IsAllocated)
+                    {
+                        handles[i].Free();
+                    }
+                }
+
+                if (pinnedSocketAddress.IsAllocated)
+                {
+                    pinnedSocketAddress.Free();
+                }
+            }
+
+            if (received == -1)
+            {
+                errno = Interop.Sys.GetLastError();
+                return -1;
+            }
+
+            socketAddressLen = (int)sockAddrLen;
+            errno = Interop.Error.SUCCESS;
+            return received;
+        }
+
+        private static unsafe int ReceiveMessageFrom(int fd, int flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
+        {
+            Debug.Assert(socketAddress != null);
+
+            var pktinfoLen = isIPv4 ? sizeof(Interop.libc.in_pktinfo) : isIPv6 ? sizeof(Interop.libc.in6_pktinfo) : 0;
+            var cmsgBufferLen = Interop.libc.cmsghdr.Size + pktinfoLen;
+            var cmsgBuffer = stackalloc byte[cmsgBufferLen];
+
+            var sockAddrLen = (uint)socketAddressLen;
+
+            int received;
+            fixed (byte* rawSocketAddress = socketAddress)
+            fixed (byte* b = buffer)
+            {
+                var sockAddr = (Interop.libc.sockaddr*)rawSocketAddress;
+
+                var iov = new Interop.libc.iovec {
+                    iov_base = &b[offset],
+                    iov_len = (IntPtr)count
+                };
+
+                var msghdr = new Interop.libc.msghdr(sockAddr, sockAddrLen, &iov, 1, cmsgBuffer, cmsgBufferLen, 0);
+                received = (int)Interop.libc.recvmsg(fd, &msghdr, flags);
+                receivedFlags = msghdr.msg_flags;
+                sockAddrLen = msghdr.msg_namelen;
+                cmsgBufferLen = (int)msghdr.msg_controllen;
+            }
+
+            ipPacketInformation = SocketPal.GetIPPacketInformation(cmsgBuffer, cmsgBufferLen, isIPv4, isIPv6);
+
+            if (received == -1)
+            {
+                errno = Interop.Sys.GetLastError();
+                return -1;
+            }
+
+            socketAddressLen = (int)sockAddrLen;
+            errno = Interop.Error.SUCCESS;
+            return received;
+        }
+
+        public static unsafe bool TryCompleteAccept(int fileDescriptor, byte[] socketAddress, ref int socketAddressLen, out int acceptedFd, out SocketError errorCode)
+        {
+            int fd;
+            uint sockAddrLen = (uint)socketAddressLen;
+            fixed (byte* rawSocketAddress = socketAddress)
+            {
+                fd = Interop.libc.accept(fileDescriptor, (Interop.libc.sockaddr*)rawSocketAddress, &sockAddrLen);
+            }
+
+            if (fd != -1)
+            {
+                // If the accept completed successfully, ensure that the accepted socket is non-blocking.
+                int err = Interop.Sys.Fcntl.SetIsNonBlocking(fd, 1);
+                if (err == 0)
+                {
+                    socketAddressLen = (int)sockAddrLen;
+                    errorCode = SocketError.Success;
+                    acceptedFd = fd;
+                }
+                else
+                {
+                    Interop.Sys.Close(fd);
+                    errorCode = GetLastSocketError();
+                    acceptedFd = -1;
+                }
+                return true;
+            }
+            acceptedFd = -1;
+
+            Interop.Error errno = Interop.Sys.GetLastError();
+            if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
+            {
+                errorCode = GetSocketErrorForErrorCode(errno);
+                return true;
+            }
+
+            errorCode = SocketError.Success;
+            return false;
+        }
+
+        public static unsafe bool TryStartConnect(int fileDescriptor, byte[] socketAddress, int socketAddressLen, out SocketError errorCode)
+        {
+            Debug.Assert(socketAddress != null);
+            Debug.Assert(socketAddressLen > 0);
+
+            int err;
+            fixed (byte* rawSocketAddress = socketAddress)
+            {
+                var sockAddr = (Interop.libc.sockaddr*)rawSocketAddress;
+                err = Interop.libc.connect(fileDescriptor, sockAddr, (uint)socketAddressLen);
+            }
+
+            if (err == 0)
+            {
+                errorCode = SocketError.Success;
+                return true;
+            }
+
+            Interop.Error errno = Interop.Sys.GetLastError();
+            if (errno != Interop.Error.EINPROGRESS)
+            {
+                errorCode = GetSocketErrorForErrorCode(errno);
+                return true;
+            }
+
+            errorCode = SocketError.Success;
+            return false;
+        }
+
+        public static unsafe bool TryCompleteConnect(int fileDescriptor, int socketAddressLen, out SocketError errorCode)
+        {
+            int socketErrno;
+			var optLen = (uint)sizeof(int);
+            int err = Interop.libc.getsockopt(fileDescriptor, Interop.libc.SOL_SOCKET, Interop.libc.SO_ERROR, &socketErrno, &optLen);
+
+            if (err != 0)
+            {
+                Debug.Fail("TryCompleteConnect: getsockopt() failed");
+                errorCode = SocketError.SocketError;
+                return true;
+            }
+			Debug.Assert(optLen == (uint)sizeof(int));
+
+            Interop.Error socketError = Interop.Sys.ConvertErrorPlatformToPal(socketErrno);
+            if (socketError == Interop.Error.SUCCESS)
+            {
+                errorCode = SocketError.Success;
+                return true;
+            }
+            else if (socketError == Interop.Error.EINPROGRESS)
+            {
+                errorCode = SocketError.Success;
+                return false;
+            }
+
+            errorCode = GetSocketErrorForErrorCode(socketError);
+
+            // On Linux, a non-blocking socket that fails a connect() attempt needs to be kicked
+            // with another connect to AF_UNSPEC before further connect() attempts will return
+            // valid errors. Otherwise, further connect() attempts will return ECONNABORTED.
+            
+            var socketAddressBuffer = stackalloc byte[socketAddressLen];
+            var sockAddr = (Interop.libc.sockaddr*)socketAddressBuffer;
+            sockAddr->sa_family = Interop.libc.AF_UNSPEC;
+
+            err = Interop.libc.connect(fileDescriptor, sockAddr, (uint)socketAddressLen);
+            Debug.Assert(err == 0, "TryCompleteConnect: failed to disassociate socket after failed connect()");
+
+            return true;
+        }
+
+        public static bool TryCompleteReceiveFrom(int fileDescriptor, byte[] buffer, int offset, int count, int flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out int receivedFlags, out SocketError errorCode)
+        {
+            return TryCompleteReceiveFrom(fileDescriptor, buffer, default(BufferList), offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
+        }
+
+        public static bool TryCompleteReceiveFrom(int fileDescriptor, IList<ArraySegment<byte>> buffers, int flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out int receivedFlags, out SocketError errorCode)
+        {
+            return TryCompleteReceiveFrom(fileDescriptor, null, new BufferList(buffers), 0, 0, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
+        }
+
+        public static unsafe bool TryCompleteReceiveFrom(int fileDescriptor, byte[] buffer, BufferList buffers, int offset, int count, int flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out int receivedFlags, out SocketError errorCode)
+        {
+            int available;
+            int err = Interop.libc.ioctl(fileDescriptor, (UIntPtr)Interop.libc.FIONREAD, &available);
+            if (err == -1)
+            {
+                bytesReceived = 0;
+                receivedFlags = 0;
+                errorCode = GetLastSocketError();
+                return true;
+            }
+            if (available == 0)
+            {
+                // Always request at least one byte.
+                available = 1;
+            }
+
+            int received;
+            Interop.Error errno;
+            if (buffer != null)
+            {
+                received = Receive(fileDescriptor, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+            }
+            else
+            {
+                Debug.Assert(buffers.IsInitialized);
+                received = Receive(fileDescriptor, flags, available, buffers, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+            }
+
+            if (received != -1)
+            {
+                bytesReceived = received;
+                errorCode = SocketError.Success;
+                return true;
+            }
+
+            bytesReceived = 0;
+
+            if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
+            {
+                errorCode = GetSocketErrorForErrorCode(errno);
+                return true;
+            }
+
+            errorCode = SocketError.Success;
+            return false;
+        }
+
+        public static unsafe bool TryCompleteReceiveMessageFrom(int fileDescriptor, byte[] buffer, int offset, int count, int flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out int receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
+        {
+            int available;
+            int err = Interop.libc.ioctl(fileDescriptor, (UIntPtr)Interop.libc.FIONREAD, &available);
+            if (err == -1)
+            {
+                bytesReceived = 0;
+                receivedFlags = 0;
+                ipPacketInformation = default(IPPacketInformation);
+                errorCode = GetLastSocketError();
+                return true;
+            }
+            if (available == 0)
+            {
+                // Always request at least one byte.
+                available = 1;
+            }
+
+            Interop.Error errno;
+            int received = ReceiveMessageFrom(fileDescriptor, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno);
+
+            if (received != -1)
+            {
+                bytesReceived = received;
+                errorCode = SocketError.Success;
+                return true;
+            }
+
+            bytesReceived = 0;
+
+            if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
+            {
+                errorCode = GetSocketErrorForErrorCode(errno);
+                return true;
+            }
+
+            errorCode = SocketError.Success;
+            return false;
+        }
+
+        public static bool TryCompleteSendTo(int fileDescriptor, byte[] buffer, ref int offset, ref int count, int flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        {
+            int bufferIndex = 0;
+            return TryCompleteSendTo(fileDescriptor, buffer, default(BufferList), ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+        }
+
+        public static bool TryCompleteSendTo(int fileDescriptor, BufferList buffers, ref int bufferIndex, ref int offset, int flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        {
+            int count = 0;
+            return TryCompleteSendTo(fileDescriptor, null, buffers, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+        }
+
+        public static bool TryCompleteSendTo(int fileDescriptor, byte[] buffer, BufferList buffers, ref int bufferIndex, ref int offset, ref int count, int flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        {
+            for (;;)
+            {
+                int sent;
+                Interop.Error errno;
+                if (buffer != null)
+                {
+                    sent = Send(fileDescriptor, flags, buffer, ref offset, ref count, socketAddress, socketAddressLen, out errno);
+                }
+                else
+                {
+                    Debug.Assert(buffers.IsInitialized);
+                    sent = Send(fileDescriptor, flags, buffers, ref bufferIndex, ref offset, socketAddress, socketAddressLen, out errno);
+                }
+
+                if (sent == -1)
+                {
+                    if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
+                    {
+                        errorCode = GetSocketErrorForErrorCode(errno);
+                        return true;
+                    }
+
+                    errorCode = SocketError.Success;
+                    return false;
+                }
+
+                bytesSent += sent;
+
+                bool isComplete = sent == 0 ||
+                    (buffer != null && count == 0) ||
+                    (buffers.IsInitialized && bufferIndex == buffers.Count);
+                if (isComplete)
+                {
+                    errorCode = SocketError.Success;
+                    return true;
+                }
+            }
+        }
+
+        public static SocketError SetBlocking(SafeCloseSocket handle, bool shouldBlock, out bool willBlock)
+        {
+            // NOTE: since we need to emulate blocking I/O on *nix (!), this does NOT change the blocking
+            //       mode of the socket. Instead, it toggles a bit on the handle to indicate whether or not
+            //       the PAL methods with blocking semantics should retry in the case of an operation that
+            //       cannot be completed synchronously.
+            handle.IsNonBlocking = !shouldBlock;
             willBlock = shouldBlock;
             return SocketError.Success;
         }
@@ -602,23 +1182,25 @@ namespace System.Net.Sockets
             return SafeCloseSocket.Accept(handle, buffer, ref nameLen);
         }
 
-        public static unsafe SocketError Connect(SafeCloseSocket handle, byte[] peerAddress, int peerAddressLen)
+        public static SocketError Connect(SafeCloseSocket handle, byte[] peerAddress, int peerAddressLen)
         {
-            int err;
-            fixed (byte* rawPeerAddress = peerAddress)
+            int fd = handle.FileDescriptor;
+
+            SocketError errorCode;
+            if (!TryStartConnect(fd, peerAddress, peerAddressLen, out errorCode))
             {
-                var peerSockAddr = (Interop.libc.sockaddr*)rawPeerAddress;
-                err = Interop.libc.connect(handle.FileDescriptor, peerSockAddr, (uint)peerAddressLen);
+                return errorCode;
             }
 
-            if (err != -1)
+            while (!TryCompleteConnect(fd, peerAddressLen, out errorCode) && !handle.IsNonBlocking)
             {
-                return SocketError.Success;
+                if (!Poll(fd, Interop.libc.PollFlags.POLLOUT, out errorCode))
+                {
+                    break;
+                }
             }
 
-            // Unix returns EINPROGRESS instead of EWOULDBLOCK for non-blocking connect operations
-            SocketError errorCode = GetLastSocketError();
-            return errorCode == SocketError.InProgress ? SocketError.WouldBlock : errorCode;
+            return errorCode;
         }
 
         public static SocketError Disconnect(Socket socket, SafeCloseSocket handle, bool reuseSocket)
@@ -626,254 +1208,182 @@ namespace System.Net.Sockets
             throw new PlatformNotSupportedException();
         }
 
-        public static unsafe SocketError Send(SafeCloseSocket handle, BufferOffsetSize[] buffers, SocketFlags socketFlags, out int bytesTransferred)
+        public static SocketError Send(SafeCloseSocket handle, BufferOffsetSize[] buffers, SocketFlags socketFlags, out int bytesTransferred)
         {
-            var iovecs = new Interop.libc.iovec[buffers.Length];
-            var handles = new GCHandle[buffers.Length];
+            int fd = handle.FileDescriptor;
+            var bufferList = new BufferList(buffers);
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
 
+            int bufferIndex = 0;
+            int offset = 0;
+            int bytesSent = 0;
 
-            try
+            SocketError errorCode;
+            while (!TryCompleteSendTo(fd, bufferList, ref bufferIndex, ref offset, platformFlags, null, 0, ref bytesSent, out errorCode) && !handle.IsNonBlocking)
             {
-                for (int i = 0; i < buffers.Length; i++)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLOUT, out errorCode))
                 {
-                    handles[i] = GCHandle.Alloc(buffers[i].Buffer, GCHandleType.Pinned);
-                    iovecs[i].iov_base = &((byte*)handles[i].AddrOfPinnedObject())[buffers[i].Offset];
-                    iovecs[i].iov_len = (IntPtr)buffers[i].Size;
-                }
-
-                int sent;
-                fixed (Interop.libc.iovec* iov = iovecs)
-                {
-                    var msghdr = new Interop.libc.msghdr(null, 0, iov, iovecs.Length, null, 0, 0);
-                    sent = (int)Interop.libc.sendmsg(handle.FileDescriptor, &msghdr, GetPlatformSocketFlags(socketFlags));
-                }
-
-                if (sent == -1)
-                {
-                    bytesTransferred = 0;
-                    return GetLastSocketError();
-                }
-
-                bytesTransferred = sent;
-                return SocketError.Success;
-            }
-            finally
-            {
-                for (int i = 0; i < handles.Length; i++)
-                {
-                    if (handles[i].IsAllocated)
-                    {
-                        handles[i].Free();
-                    }
+                    break;
                 }
             }
+
+            bytesTransferred = bytesSent;
+            return errorCode;
         }
 
-        public static unsafe SocketError Send(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out int bytesTransferred)
+        public static SocketError Send(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out int bytesTransferred)
         {
-            var iovecs = new Interop.libc.iovec[buffers.Count];
-            var handles = new GCHandle[buffers.Count];
+            int fd = handle.FileDescriptor;
+            var bufferList = new BufferList(buffers);
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
 
-            try
+            int bufferIndex = 0;
+            int offset = 0;
+            int bytesSent = 0;
+
+            SocketError errorCode;
+            while (!TryCompleteSendTo(fd, bufferList, ref bufferIndex, ref offset, platformFlags, null, 0, ref bytesSent, out errorCode) && !handle.IsNonBlocking)
             {
-                for (int i = 0; i < buffers.Count; i++)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLOUT, out errorCode))
                 {
-                    handles[i] = GCHandle.Alloc(buffers[i].Array, GCHandleType.Pinned);
-                    iovecs[i].iov_base = &((byte*)handles[i].AddrOfPinnedObject())[buffers[i].Offset];
-                    iovecs[i].iov_len = (IntPtr)buffers[i].Count;
-                }
-
-                int sent;
-                fixed (Interop.libc.iovec* iov = iovecs)
-                {
-                    var msghdr = new Interop.libc.msghdr(null, 0, iov, iovecs.Length, null, 0, 0);
-                    sent = (int)Interop.libc.sendmsg(handle.FileDescriptor, &msghdr, GetPlatformSocketFlags(socketFlags));
-                }
-
-                if (sent == -1)
-                {
-                    bytesTransferred = 0;
-                    return GetLastSocketError();
-                }
-
-                bytesTransferred = sent;
-                return SocketError.Success;
-            }
-            finally
-            {
-                for (int i = 0; i < handles.Length; i++)
-                {
-                    if (handles[i].IsAllocated)
-                    {
-                        handles[i].Free();
-                    }
+                    break;
                 }
             }
+
+            bytesTransferred = bytesSent;
+            return errorCode;
         }
 
-        // TODO: refactor to accommodate GetLastSocketError
-        public static unsafe int Send(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        public static SocketError Send(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, out int bytesTransferred)
         {
-            int sent;
-            if (buffer.Length == 0)
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            int bytesSent = 0;
+
+            SocketError errorCode;
+            while (!TryCompleteSendTo(fd, buffer, ref offset, ref size, platformFlags, null, 0, ref bytesSent, out errorCode) && !handle.IsNonBlocking)
             {
-                sent = (int)Interop.libc.send(handle.FileDescriptor, null, IntPtr.Zero, GetPlatformSocketFlags(socketFlags));
-            }
-            else
-            {
-                fixed (byte* pinnedBuffer = buffer)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLOUT, out errorCode))
                 {
-                    sent = (int)Interop.libc.send(handle.FileDescriptor, &pinnedBuffer[offset], (IntPtr)size, GetPlatformSocketFlags(socketFlags));
+                    break;
                 }
             }
 
-            return sent;
+            bytesTransferred = bytesSent;
+            return errorCode;
         }
 
-        // TODO: refactor to accommodate GetLastSocketError
-        public static unsafe int SendTo(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, int peerAddressSize)
+        public static SocketError SendTo(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, int peerAddressSize, out int bytesTransferred)
         {
-            int sent;
-            fixed (byte* rawPeerAddress = peerAddress)
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            int bytesSent = 0;
+
+            SocketError errorCode;
+            while (!TryCompleteSendTo(fd, buffer, ref offset, ref size, platformFlags, peerAddress, peerAddressSize, ref bytesSent, out errorCode) && !handle.IsNonBlocking)
             {
-                Interop.libc.sockaddr* peerSockAddr = (Interop.libc.sockaddr*)rawPeerAddress;
-                if (buffer.Length == 0)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLOUT, out errorCode))
                 {
-                    sent = (int)Interop.libc.sendto(handle.FileDescriptor, null, IntPtr.Zero, GetPlatformSocketFlags(socketFlags), peerSockAddr, (uint)peerAddressSize);
-                }
-                else
-                {
-                    fixed (byte* pinnedBuffer = buffer)
-                    {
-                        sent = (int)Interop.libc.sendto(handle.FileDescriptor, &pinnedBuffer[offset], (IntPtr)size, GetPlatformSocketFlags(socketFlags), peerSockAddr, (uint)peerAddressSize);
-                    }
+                    break;
                 }
             }
 
-            return sent;
+            bytesTransferred = bytesSent;
+            return errorCode;
         }
 
-        public static unsafe SocketError Receive(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, ref SocketFlags socketFlags, out int bytesTransferred)
+        public static SocketError Receive(SafeCloseSocket handle, IList<ArraySegment<byte>> buffers, ref SocketFlags socketFlags, out int bytesTransferred)
         {
-            var iovecs = new Interop.libc.iovec[buffers.Count];
-            var handles = new GCHandle[buffers.Count];
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
 
-            try
+            int socketAddressLen = 0;
+            int bytesReceived;
+            int receiveFlags;
+            SocketError errorCode;
+            while (!TryCompleteReceiveFrom(fd, buffers, platformFlags, null, ref socketAddressLen, out bytesReceived, out receiveFlags, out errorCode) && !handle.IsNonBlocking)
             {
-                for (int i = 0; i < buffers.Count; i++)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLIN, out errorCode))
                 {
-                    handles[i] = GCHandle.Alloc(buffers[i].Array, GCHandleType.Pinned);
-                    iovecs[i].iov_base = &((byte*)handles[i].AddrOfPinnedObject())[buffers[i].Offset];
-                    iovecs[i].iov_len = (IntPtr)buffers[i].Count;
-                }
-
-                int received;
-                fixed (Interop.libc.iovec* iov = iovecs)
-                {
-                    var msghdr = new Interop.libc.msghdr(null, 0, iov, iovecs.Length, null, 0, 0);
-                    received = (int)Interop.libc.recvmsg(handle.FileDescriptor, &msghdr, GetPlatformSocketFlags(socketFlags));
-                }
-
-                if (received == -1)
-                {
-                    bytesTransferred = 0;
-                    return GetLastSocketError();
-                }
-
-                bytesTransferred = received;
-                return SocketError.Success;
-            }
-            finally
-            {
-                for (int i = 0; i < handles.Length; i++)
-                {
-                    if (handles[i].IsAllocated)
-                    {
-                        handles[i].Free();
-                    }
+                    break;
                 }
             }
+
+            socketFlags = GetSocketFlags(receiveFlags);
+            bytesTransferred = bytesReceived;
+            return errorCode;
         }
 
-        // TODO: refactor to accommodate GetLastSocketError
-        public static unsafe int Receive(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        public static SocketError Receive(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, out int bytesTransferred)
         {
-            int received;
-            if (buffer.Length == 0)
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            int socketAddressLen = 0;
+            int bytesReceived;
+            int receiveFlags;
+            SocketError errorCode;
+            while (!TryCompleteReceiveFrom(fd, buffer, offset, size, platformFlags, null, ref socketAddressLen, out bytesReceived, out receiveFlags, out errorCode) && !handle.IsNonBlocking)
             {
-                received = (int)Interop.libc.recv(handle.FileDescriptor, null, IntPtr.Zero, GetPlatformSocketFlags(socketFlags));
-            }
-            else
-            {
-                fixed (byte* pinnedBuffer = buffer)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLIN, out errorCode))
                 {
-                    received = (int)Interop.libc.recv(handle.FileDescriptor, &pinnedBuffer[offset], (IntPtr)size, GetPlatformSocketFlags(socketFlags));
+                    break;
                 }
             }
 
-            return received;
+            socketFlags = GetSocketFlags(receiveFlags);
+            bytesTransferred = bytesReceived;
+            return errorCode;
         }
 
-        public static unsafe SocketError ReceiveMessageFrom(Socket socket, SafeCloseSocket handle, byte[] buffer, int offset, int size, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
+        public static SocketError ReceiveMessageFrom(Socket socket, SafeCloseSocket handle, byte[] buffer, int offset, int size, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
         {
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+            byte[] socketAddressBuffer = socketAddress.Buffer;
+            int socketAddressLen = socketAddress.Size;
+
             bool isIPv4, isIPv6;
             Socket.GetIPProtocolInformation(socket.AddressFamily, socketAddress, out isIPv4, out isIPv6);
 
-            var pktinfoLen = isIPv4 ? sizeof(Interop.libc.in_pktinfo) : isIPv6 ? sizeof(Interop.libc.in6_pktinfo) : 0;
-            var cmsgBufferLen = Interop.libc.cmsghdr.Size + pktinfoLen;
-            var cmsgBuffer = stackalloc byte[cmsgBufferLen];
-
-            int received;
-            fixed (byte* peerAddress = socketAddress.Buffer)
-            fixed (byte* pinnedBuffer = buffer)
+            int bytesReceived;
+            int receiveFlags;
+            SocketError errorCode;
+            while (!TryCompleteReceiveMessageFrom(fd, buffer, offset, size, platformFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receiveFlags, out ipPacketInformation, out errorCode) && !handle.IsNonBlocking)
             {
-                var iovec = new Interop.libc.iovec {
-                    iov_base = &pinnedBuffer[offset],
-                    iov_len = (IntPtr)size
-                };
-
-                var msghdr = new Interop.libc.msghdr(peerAddress, (uint)socketAddress.Size, &iovec, 1, cmsgBuffer, cmsgBufferLen, 0);
-                received = (int)Interop.libc.recvmsg(handle.FileDescriptor, &msghdr, GetPlatformSocketFlags(socketFlags));
-                socketAddress.InternalSize = (int)msghdr.msg_namelen; // TODO: is this OK?
-                cmsgBufferLen = (int)msghdr.msg_controllen;
+                if (!Poll(fd, Interop.libc.PollFlags.POLLIN, out errorCode))
+                {
+                    break;
+                }
             }
 
+            socketAddress.InternalSize = socketAddressLen;
             receiveAddress = socketAddress;
-            ipPacketInformation = GetIPPacketInformation(cmsgBuffer, cmsgBufferLen, isIPv4, isIPv6);
-
-            if (received == -1)
-            {
-                bytesTransferred = 0;
-                return GetLastSocketError();
-            }
-
-            bytesTransferred = received;
-            return SocketError.Success;
+            socketFlags = GetSocketFlags(receiveFlags);
+            bytesTransferred = bytesReceived;
+            return errorCode;
         }
 
-        // TODO: refactor to accommodate GetLastSocketError
-        public static unsafe int ReceiveFrom(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, ref int addressLength)
+        public static SocketError ReceiveFrom(SafeCloseSocket handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, ref int addressLength, out int bytesTransferred)
         {
-            int received;
-            uint peerAddrLen = (uint)addressLength;
-            fixed (byte* rawPeerAddress = peerAddress)
+            int fd = handle.FileDescriptor;
+            int platformFlags = GetPlatformSocketFlags(socketFlags);
+
+            int bytesReceived;
+            int receiveFlags;
+            SocketError errorCode;
+            while (!TryCompleteReceiveFrom(fd, buffer, offset, size, platformFlags, peerAddress, ref addressLength, out bytesReceived, out receiveFlags, out errorCode) && !handle.IsNonBlocking)
             {
-                Interop.libc.sockaddr* peerSockAddr = (Interop.libc.sockaddr*)rawPeerAddress;
-                if (buffer.Length == 0)
+                if (!Poll(fd, Interop.libc.PollFlags.POLLIN, out errorCode))
                 {
-                    received = (int)Interop.libc.recvfrom(handle.FileDescriptor, null, IntPtr.Zero, GetPlatformSocketFlags(socketFlags), peerSockAddr, &peerAddrLen);
-                }
-                else
-                {
-                    fixed (byte* pinnedBuffer = buffer)
-                    {
-                        received = (int)Interop.libc.recvfrom(handle.FileDescriptor, &pinnedBuffer[offset], (IntPtr)size, GetPlatformSocketFlags(socketFlags), peerSockAddr, &peerAddrLen);
-                    }
+                    break;
                 }
             }
 
-            addressLength = (int)peerAddrLen;
-            return received;
+            bytesTransferred = bytesReceived;
+            return errorCode;
         }
 
         public static SocketError Ioctl(SafeCloseSocket handle, int ioControlCode, byte[] optionInValue, byte[] optionOutValue, out int optionLength)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/_AcceptOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/_AcceptOverlappedAsyncResult.Unix.cs
@@ -32,12 +32,15 @@ namespace System.Net.Sockets
             _buffer = null;
             _localBytesTransferred = 0;
 
-            Internals.SocketAddress remoteSocketAddress = IPEndPointExtensions.Serialize(_listenSocket.m_RightEndPoint);
-            System.Buffer.BlockCopy(socketAddress, 0, remoteSocketAddress.Buffer, 0, socketAddressLen);
+			if (errorCode == SocketError.Success)
+			{
+				Internals.SocketAddress remoteSocketAddress = IPEndPointExtensions.Serialize(_listenSocket.m_RightEndPoint);
+				System.Buffer.BlockCopy(socketAddress, 0, remoteSocketAddress.Buffer, 0, socketAddressLen);
 
-            _acceptedSocket = _listenSocket.CreateAcceptSocket(
-                SafeCloseSocket.CreateSocket(acceptedFileDescriptor),
-                _listenSocket.m_RightEndPoint.Create(remoteSocketAddress));
+				_acceptedSocket = _listenSocket.CreateAcceptSocket(
+					SafeCloseSocket.CreateSocket(acceptedFileDescriptor),
+					_listenSocket.m_RightEndPoint.Create(remoteSocketAddress));
+			}
 
             base.CompletionCallback(0, errorCode);
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/_ConnectOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/_ConnectOverlappedAsyncResult.Unix.cs
@@ -27,7 +27,9 @@ namespace System.Net.Sockets
             var errorCode = (SocketError)ErrorCode;
             if (errorCode == SocketError.Success)
             {
-                return (Socket)AsyncObject;
+                var socket = (Socket)AsyncObject;
+                socket.SetToConnected();
+                return socket;
             }
 
             return null;


### PR DESCRIPTION
Winsock considers the {non,}blocking option of a socket separately from the overlapped option for the same. As a result, a blocking socket can be used for nonblocking I/O on Windows, provided the overlapped APIs are used. As these APIs are what is used under the covers by the asynchronous Socket APIs, this behavior leaks through (intentionally or otherwise) to Socket: a blocking Socket can be used for async I/O without any special consideration.

Unfortunately, no other platform allows non-blocking I/O on a blocking socket. This change moves _all_ socket I/O on non-Windows platforms onto non-blocking sockets in order to support the Winsock-style semantics. Blocking I/O is emulated using async I/O and events.
