### PR TITLE
Address some issues with the Sockets tests.

### DIFF
--- a/src/Common/tests/System.Net/Sockets/Performance/SocketTestClient.cs
+++ b/src/Common/tests/System.Net/Sockets/Performance/SocketTestClient.cs
@@ -178,7 +178,7 @@ namespace System.Net.Sockets.Performance.Tests
             _recvBufferIndex = 0;
 
             // Expect echo server.
-            if (!Compare(_sendBuffer, _recvBuffer))
+            if (!SocketTestMemcmp.Compare(_sendBuffer, _recvBuffer))
             {
                 _log.WriteLine("Received different data from echo server");
             }
@@ -238,23 +238,5 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         protected abstract string ImplementationName();
-
-        private static bool Compare(byte[] b1, byte[] b2)
-        {
-            if (b1.Length != b2.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < b1.Length; i++)
-            {
-                if (b1[i] != b2[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
     }
 }

--- a/src/Common/tests/System.Net/Sockets/Performance/SocketTestClient.cs
+++ b/src/Common/tests/System.Net/Sockets/Performance/SocketTestClient.cs
@@ -178,7 +178,7 @@ namespace System.Net.Sockets.Performance.Tests
             _recvBufferIndex = 0;
 
             // Expect echo server.
-            if (memcmp(_sendBuffer, _recvBuffer, _sendBuffer.Length) != 0)
+            if (!Compare(_sendBuffer, _recvBuffer))
             {
                 _log.WriteLine("Received different data from echo server");
             }
@@ -238,9 +238,23 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         protected abstract string ImplementationName();
-        
-        //TODO: Either find a different fast way to compare or extract this in Interop.
-        [DllImport("msvcrt.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int memcmp(byte[] b1, byte[] b2, long count);
+
+        private static bool Compare(byte[] b1, byte[] b2)
+        {
+            if (b1.Length != b2.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < b1.Length; i++)
+            {
+                if (b1[i] != b2[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/src/Common/tests/System.Net/Sockets/Performance/SocketTestMemcmp.Unix.cs
+++ b/src/Common/tests/System.Net/Sockets/Performance/SocketTestMemcmp.Unix.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net.Sockets.Performance.Tests
+{
+    internal static class SocketTestMemcmp
+    {
+        public static bool Compare(byte[] b1, byte[] b2)
+        {
+            if (b1.Length != b2.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < b1.Length; i++)
+            {
+                if (b1[i] != b2[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Common/tests/System.Net/Sockets/Performance/SocketTestMemcmp.Windows.cs
+++ b/src/Common/tests/System.Net/Sockets/Performance/SocketTestMemcmp.Windows.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Net.Sockets.Performance.Tests
+{
+    internal static class SocketTestMemcmp
+    {
+        [DllImport("msvcrt.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int memcmp(byte[] b1, byte[] b2, long count);
+
+        public static bool Compare(byte[] b1, byte[] b2)
+        {
+            return b1.Length == b2.Length && memcmp(b1, b2, b1.Length) == 0;
+        }
+    }
+}

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/Disconnect.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/Disconnect.cs
@@ -15,6 +15,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Success()
         {
             AutoResetEvent completed = new AutoResetEvent(false);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/Disconnect.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/Disconnect.cs
@@ -49,5 +49,49 @@ namespace System.Net.Sockets.Tests
                 }
             }
         }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void DisconnectAsync_Throws_PlatformNotSupported()
+        {
+            const int Port = TestPortBase + 2;
+
+            IPAddress address = null;
+            if (Socket.OSSupportsIPv4)
+            {
+                address = IPAddress.Loopback;
+            }
+            else if (Socket.OSSupportsIPv6)
+            {
+                address = IPAddress.IPv6Loopback;
+            }
+            else
+            {
+                return;
+            }
+
+            var endPoint = new IPEndPoint(address, Port);
+            using (SocketTestServer.ServerFactory(endPoint))
+            {
+                var completed = new AutoResetEvent(false);
+
+                var args = new SocketAsyncEventArgs {
+                    UserToken = completed,
+                    RemoteEndPoint = endPoint,
+                    DisconnectReuseSocket = true
+                };
+                args.Completed += OnCompleted;
+
+                var client = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                Assert.True(client.ConnectAsync(args));
+                Assert.True(completed.WaitOne(5000), "Timed out while waiting for connection");
+                Assert.Equal<SocketError>(SocketError.Success, args.SocketError);
+
+                Assert.Throws<PlatformNotSupportedException>(client.Disconnect(true));
+
+                client.Dispose();
+            }
+        }
+
     }
 }

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DisconnectAsync.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DisconnectAsync.cs
@@ -15,6 +15,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Success()
         {
             AutoResetEvent completed = new AutoResetEvent(false);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DnsEndPointTest.cs
@@ -7,13 +7,15 @@ namespace System.Net.Sockets.Tests
 {
     public class DnsEndPointTest
     {
+        private const int TestPortBase = 8080;
+
         [Fact]
         public void Socket_ConnectDnsEndPoint_Success()
         {
-            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, 8080));
+            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, TestPortBase));
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            sock.Connect(new DnsEndPoint("localhost", 8080));
+            sock.Connect(new DnsEndPoint("localhost", TestPortBase));
 
             sock.Dispose();
             server.Dispose();
@@ -26,7 +28,7 @@ namespace System.Net.Sockets.Tests
             {
                 // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 SocketException ex = Assert.ThrowsAny<SocketException>(() => {
-                    sock.Connect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", 8080));
+                    sock.Connect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", TestPortBase + 1));
                 });
 
                 SocketError errorCode = ex.SocketErrorCode;
@@ -35,7 +37,7 @@ namespace System.Net.Sockets.Tests
 
                 // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 ex = Assert.ThrowsAny<SocketException>(() => {
-                    sock.Connect(new DnsEndPoint("localhost", 8081));
+                    sock.Connect(new DnsEndPoint("localhost", TestPortBase + 2));
                 });
 
                 Assert.Equal(SocketError.ConnectionRefused, ex.SocketErrorCode);
@@ -48,7 +50,7 @@ namespace System.Net.Sockets.Tests
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
                 Assert.Throws<ArgumentException>(() => {
-                    sock.SendTo(new byte[10], new DnsEndPoint("localhost", 8080));
+                    sock.SendTo(new byte[10], new DnsEndPoint("localhost", TestPortBase + 3));
                 });
             }
         }
@@ -58,8 +60,8 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
-                sock.Bind(new IPEndPoint(IPAddress.Loopback, 8080));
-                EndPoint endpoint = new DnsEndPoint("localhost", 8080);
+                sock.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 4));
+                EndPoint endpoint = new DnsEndPoint("localhost", TestPortBase + 4);
 
                 Assert.Throws<ArgumentException>(() => {
                     sock.ReceiveFrom(new byte[10], ref endpoint);
@@ -70,10 +72,10 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void Socket_BeginConnectDnsEndPoint_Success()
         {
-            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, 8080));
+            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, TestPortBase + 5));
 
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            IAsyncResult result = sock.BeginConnect(new DnsEndPoint("localhost", 8080), null, null);
+            IAsyncResult result = sock.BeginConnect(new DnsEndPoint("localhost", TestPortBase + 5), null, null);
             sock.EndConnect(result);
 
             sock.Dispose();
@@ -87,7 +89,7 @@ namespace System.Net.Sockets.Tests
             {
                 // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 SocketException ex = Assert.ThrowsAny<SocketException>(() => {
-                    IAsyncResult result = sock.BeginConnect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", 8080), null, null);
+                    IAsyncResult result = sock.BeginConnect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", TestPortBase + 6), null, null);
                     sock.EndConnect(result);
                 });
 
@@ -97,7 +99,7 @@ namespace System.Net.Sockets.Tests
 
                 // TODO: Behavior difference from .Net Desktop. This will actually throw InternalSocketException.
                 ex = Assert.ThrowsAny<SocketException>(() => {
-                    IAsyncResult result = sock.BeginConnect(new DnsEndPoint("localhost", 8080), null, null);
+                    IAsyncResult result = sock.BeginConnect(new DnsEndPoint("localhost", TestPortBase + 6), null, null);
                     sock.EndConnect(result);
                 });
 
@@ -111,7 +113,7 @@ namespace System.Net.Sockets.Tests
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
                 Assert.Throws<ArgumentException>(() => {
-                    sock.BeginSendTo(new byte[10], 0, 0, SocketFlags.None, new DnsEndPoint("localhost", 8080), null, null);
+                    sock.BeginSendTo(new byte[10], 0, 0, SocketFlags.None, new DnsEndPoint("localhost", TestPortBase + 7), null, null);
                 });
             }
         }
@@ -125,10 +127,10 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void Socket_ConnectAsyncDnsEndPoint_Success()
         {
-            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, 8080));
+            SocketTestServer server = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, TestPortBase + 8));
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 8);
             args.Completed += OnConnectAsyncCompleted;
             
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -151,7 +153,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_ConnectAsyncDnsEndPoint_HostNotFound()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", TestPortBase + 9);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -172,7 +174,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_ConnectAsyncDnsEndPoint_ConnectionRefused()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 10);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -197,11 +199,11 @@ namespace System.Net.Sockets.Tests
 
             Assert.True(Capability.IPv6Support() && Capability.IPv4Support());
 
-            SocketTestServer server4 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, 8080));
-            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.IPv6Loopback, 8081));
+            SocketTestServer server4 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.Loopback, TestPortBase + 11));
+            SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 12));
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 11);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -219,7 +221,7 @@ namespace System.Net.Sockets.Tests
 
             args.ConnectSocket.Dispose();
 
-            args.RemoteEndPoint = new DnsEndPoint("localhost", 8081);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 12);
             complete.Reset();
 
             Assert.True(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));
@@ -242,7 +244,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_StaticConnectAsync_HostNotFound()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", TestPortBase + 13);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -263,7 +265,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_StaticConnectAsync_ConnectionRefused()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", 8080);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 14);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -292,7 +294,7 @@ namespace System.Net.Sockets.Tests
             Assert.True(Capability.IPv6Support()); // IPv6 required because we use AF.InterNetworkV6
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("127.0.0.1", 8080, AddressFamily.InterNetworkV6);
+            args.RemoteEndPoint = new DnsEndPoint("127.0.0.1", TestPortBase + 15, AddressFamily.InterNetworkV6);
             args.Completed += CallbackThatShouldNotBeCalled;
 
             Assert.False(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -8,6 +8,9 @@ namespace System.Net.Sockets.Tests
 {
     public class DualMode
     {
+        private const int DummyDualModeV6Issue = 8000;
+        private const int DummyErrorMismatchIssue = 8001;
+
         private const int TestPortBase = 8200;  // to 8300
         private readonly ITestOutputHelper _log;
 
@@ -74,32 +77,32 @@ namespace System.Net.Sockets.Tests
         [Fact] // Base Case
         public void ConnectV4MappedIPAddressToV4Host_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, false);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, false, TestPortBase + 1);
         }
 
         [Fact] // Base Case
         public void ConnectV4MappedIPAddressToDualHost_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.IPv6Any, true);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.IPv6Any, true, TestPortBase + 2);
         }
 
         [Fact]
         public void ConnectV4IPAddressToV4Host_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 3);
         }
 
         [Fact]
         public void ConnectV6IPAddressToV6Host_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 4);
         }
 
         [Fact]
         public void ConnectV4IPAddressToV6Host_Fails()
         {
-            Assert.Throws<SocketException>( () => { 
-                DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+            Assert.Throws<SocketException>(() => { 
+                DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 5);
             });
         }
 
@@ -107,28 +110,28 @@ namespace System.Net.Sockets.Tests
         public void ConnectV6IPAddressToV4Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 6);
             });
         }
 
         [Fact]
         public void ConnectV4IPAddressToDualHost_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 7);
         }
 
         [Fact]
         public void ConnectV6IPAddressToDualHost_Success()
         {
-            DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 8);
         }
 
-        private void DualModeConnect_IPAddressToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnect_IPAddressToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 1))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                socket.Connect(connectTo, TestPortBase + 1);
+                socket.Connect(connectTo, port);
                 Assert.True(socket.Connected);
             }
         }
@@ -144,39 +147,39 @@ namespace System.Net.Sockets.Tests
             socket.DualMode = false;
 
             Assert.Throws<SocketException>(() => {
-                socket.Connect(new IPEndPoint(IPAddress.Loopback, TestPortBase + 2));
+                socket.Connect(new IPEndPoint(IPAddress.Loopback, TestPortBase + 10));
             });
         }
 
         [Fact] // Base case
         public void ConnectV4MappedIPEndPointToV4Host_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, false);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, false, TestPortBase + 11);
         }
 
         [Fact] // Base case
         public void ConnectV4MappedIPEndPointToDualHost_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.IPv6Any, true);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.IPv6Any, true, TestPortBase + 12);
         }
 
         [Fact]
         public void ConnectV4IPEndPointToV4Host_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 13);
         }
 
         [Fact]
         public void ConnectV6IPEndPointToV6Host_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 14);
         }
 
         [Fact]
         public void ConnectV4IPEndPointToV6Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 15);
             });
         }
 
@@ -184,28 +187,28 @@ namespace System.Net.Sockets.Tests
         public void ConnectV6IPEndPointToV4Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 16);
             });
         }
 
         [Fact]
         public void ConnectV4IPEndPointToDualHost_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 17);
         }
 
         [Fact]
         public void ConnectV6IPEndPointToDualHost_Success()
         {
-            DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 18);
         }
 
-        private void DualModeConnect_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnect_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 3))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {                
-                socket.Connect(new IPEndPoint(connectTo, TestPortBase + 3));
+                socket.Connect(new IPEndPoint(connectTo, port));
                 Assert.True(socket.Connected);
             }
         }
@@ -220,10 +223,10 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             socket.DualMode = false;
-            using (SocketServer server = new SocketServer(_log, IPAddress.Loopback, false, TestPortBase + 4))
+            using (SocketServer server = new SocketServer(_log, IPAddress.Loopback, false, TestPortBase + 20))
             {
                 Assert.Throws<ArgumentException>(() => {
-                    socket.Connect(new IPAddress[] { IPAddress.Loopback }, TestPortBase + 4);
+                    socket.Connect(new IPAddress[] { IPAddress.Loopback }, TestPortBase + 20);
                 });
             }
         }
@@ -233,7 +236,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback.MapToIPv6() },
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 21);
         }
 
         [Fact]
@@ -242,7 +245,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<SocketException>(() => {
                 DualModeConnect_IPAddressListToHost_Helper(
                     new IPAddress[] { IPAddress.Loopback.MapToIPv6() },
-                    IPAddress.IPv6Loopback, false);
+                    IPAddress.IPv6Loopback, false, TestPortBase + 22);
             });
         }
 
@@ -251,7 +254,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback },
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 23);
         }
 
         [Fact]
@@ -260,7 +263,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<SocketException>(() => {
                 DualModeConnect_IPAddressListToHost_Helper(
                     new IPAddress[] { IPAddress.Loopback },
-                    IPAddress.IPv6Loopback, false);
+                    IPAddress.IPv6Loopback, false, TestPortBase + 24);
             });
         }
 
@@ -270,7 +273,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<SocketException>(() => {
                 DualModeConnect_IPAddressListToHost_Helper(
                     new IPAddress[] { IPAddress.Loopback },
-                    IPAddress.IPv6Any, false);
+                    IPAddress.IPv6Any, false, TestPortBase + 25);
             });
         }
 
@@ -280,7 +283,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<SocketException>(() => {
                 DualModeConnect_IPAddressListToHost_Helper(
                     new IPAddress[] { IPAddress.Loopback },
-                    IPAddress.IPv6Loopback, true);
+                    IPAddress.IPv6Loopback, true, TestPortBase + 26);
             });
         }
 
@@ -289,7 +292,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback },
-                IPAddress.IPv6Any, true);
+                IPAddress.IPv6Any, true, TestPortBase + 27);
         }
         
         [Fact]
@@ -297,7 +300,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback }, 
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 28);
         }
 
         [Fact]
@@ -305,7 +308,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 29);
         }
 
         [Fact]
@@ -313,7 +316,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback },
-                IPAddress.IPv6Loopback, false);
+                IPAddress.IPv6Loopback, false, TestPortBase + 30);
         }
 
         [Fact]
@@ -321,7 +324,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.IPv6Loopback, false);
+                IPAddress.IPv6Loopback, false, TestPortBase + 31);
         }
 
         [Fact]
@@ -329,7 +332,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback },
-                IPAddress.IPv6Any, true);
+                IPAddress.IPv6Any, true, TestPortBase + 32);
         }
 
         [Fact]
@@ -337,15 +340,15 @@ namespace System.Net.Sockets.Tests
         {
             DualModeConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.IPv6Any, true);
+                IPAddress.IPv6Any, true, TestPortBase + 33);
         }
 
-        private void DualModeConnect_IPAddressListToHost_Helper(IPAddress[] connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnect_IPAddressListToHost_Helper(IPAddress[] connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 5))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                socket.Connect(connectTo, TestPortBase + 5);
+                socket.Connect(connectTo, port);
                 Assert.True(socket.Connected);
             }
         }
@@ -357,27 +360,27 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ConnectLoopbackToV4Host_Success()
         {
-            DualModeConnect_LoopackDnsToHost_Helper(IPAddress.Loopback, false);
+            DualModeConnect_LoopbackDnsToHost_Helper(IPAddress.Loopback, false, TestPortBase + 40);
         }
 
         [Fact]
         public void ConnectLoopbackToV6Host_Success()
         {
-            DualModeConnect_LoopackDnsToHost_Helper(IPAddress.IPv6Loopback, false);
+            DualModeConnect_LoopbackDnsToHost_Helper(IPAddress.IPv6Loopback, false, TestPortBase + 41);
         }
 
         [Fact]
         public void ConnectLoopbackToDualHost_Success()
         {
-            DualModeConnect_LoopackDnsToHost_Helper(IPAddress.IPv6Any, true);
+            DualModeConnect_LoopbackDnsToHost_Helper(IPAddress.IPv6Any, true, TestPortBase + 42);
         }
 
-        private void DualModeConnect_LoopackDnsToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnect_LoopbackDnsToHost_Helper(IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 6))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                socket.Connect("loopback", TestPortBase + 6);
+                socket.Connect("localhost", port);
                 Assert.True(socket.Connected);
             }
         }
@@ -389,27 +392,27 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void DualModeSocket_DnsEndPointToV4Host_Success()
         {
-            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.Loopback, false, AddressFamily.Unspecified);
+            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.Loopback, false, AddressFamily.Unspecified, TestPortBase + 50);
         }
 
         [Fact]
         public void DualModeSocket_DnsEndPointToV6Host_Success()
         {
-            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false, AddressFamily.Unspecified);
+            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false, AddressFamily.Unspecified, TestPortBase + 51);
         }
 
         [Fact]
         public void DualModeSocket_DnsEndPointToDualHost_Success()
         {
-            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true, AddressFamily.Unspecified);
+            DualModeConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true, AddressFamily.Unspecified, TestPortBase + 52);
         }
 
-        private void DualModeConnect_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer, AddressFamily addressFamily)
+        private void DualModeConnect_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer, AddressFamily addressFamily, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 49))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                socket.Connect(new DnsEndPoint("loopback", TestPortBase + 49, addressFamily));
+                socket.Connect(new DnsEndPoint("localhost", port, addressFamily));
                 Assert.True(socket.Connected);
             }
         }
@@ -429,27 +432,27 @@ namespace System.Net.Sockets.Tests
             socket.DualMode = false;
 
             Assert.Throws<NotSupportedException>(() => {
-                socket.BeginConnect(IPAddress.Loopback, TestPortBase + 39, null, null);
+                socket.BeginConnect(IPAddress.Loopback, TestPortBase + 60, null, null);
             });
         }
 
         [Fact]
         public void BeginConnectV4IPAddressToV4Host_Success()
         {
-            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 61);
         }
 
         [Fact]
         public void BeginConnectV6IPAddressToV6Host_Success()
         {
-            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 62);
         }
 
         [Fact]
         public void BeginConnectV4IPAddressToV6Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 63);
             });
         }
 
@@ -457,28 +460,28 @@ namespace System.Net.Sockets.Tests
         public void BeginConnectV6IPAddressToV4Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 64);
             });
         }
 
         [Fact]
         public void BeginConnectV4IPAddressToDualHost_Success()
         {
-            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 65);
         }
 
         [Fact]
         public void BeginConnectV6IPAddressToDualHost_Success()
         {
-            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 66);
         }
 
-        private void DualModeBeginConnect_IPAddressToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginConnect_IPAddressToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 7))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                IAsyncResult async = socket.BeginConnect(connectTo, TestPortBase + 7, null, null);
+                IAsyncResult async = socket.BeginConnect(connectTo, port, null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -495,27 +498,27 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             socket.DualMode = false;
             Assert.Throws<SocketException>(() => {
-                socket.BeginConnect(new IPEndPoint(IPAddress.Loopback, TestPortBase + 8), null, null);
+                socket.BeginConnect(new IPEndPoint(IPAddress.Loopback, TestPortBase + 70), null, null);
             });
         }
 
         [Fact]
         public void BeginConnectV4IPEndPointToV4Host_Success()
         {
-            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 71);
         }
 
         [Fact]
         public void BeginConnectV6IPEndPointToV6Host_Success()
         {
-            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 72);
         }
 
         [Fact]
         public void BeginConnectV4IPEndPointToV6Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 73);
             });
         }
 
@@ -523,28 +526,28 @@ namespace System.Net.Sockets.Tests
         public void BeginConnectV6IPEndPointToV4Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 74);
             });
         }
 
         [Fact]
         public void BeginConnectV4IPEndPointToDualHost_Success()
         {
-            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 75);
         }
 
         [Fact]
         public void BeginConnectV6IPEndPointToDualHost_Success()
         {
-            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 76);
         }
 
-        private void DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 9))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                IAsyncResult async = socket.BeginConnect(new IPEndPoint(connectTo, TestPortBase + 9), null, null);
+                IAsyncResult async = socket.BeginConnect(new IPEndPoint(connectTo, port), null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -559,7 +562,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback },
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 80);
         }
 
         [Fact]
@@ -567,7 +570,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.Loopback, false);
+                IPAddress.Loopback, false, TestPortBase + 81);
         }
 
         [Fact]
@@ -575,7 +578,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback },
-                IPAddress.IPv6Loopback, false);
+                IPAddress.IPv6Loopback, false, TestPortBase + 82);
         }
 
         [Fact]
@@ -583,7 +586,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.IPv6Loopback, false);
+                IPAddress.IPv6Loopback, false, TestPortBase + 83);
         }
 
         [Fact]
@@ -591,7 +594,7 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.Loopback, IPAddress.IPv6Loopback },
-                IPAddress.IPv6Any, true);
+                IPAddress.IPv6Any, true, TestPortBase + 84);
         }
 
         [Fact]
@@ -599,15 +602,15 @@ namespace System.Net.Sockets.Tests
         {
             DualModeBeginConnect_IPAddressListToHost_Helper(
                 new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback },
-                IPAddress.IPv6Any, true);
+                IPAddress.IPv6Any, true, TestPortBase + 85);
         }
 
-        private void DualModeBeginConnect_IPAddressListToHost_Helper(IPAddress[] connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginConnect_IPAddressListToHost_Helper(IPAddress[] connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 10))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                IAsyncResult async = socket.BeginConnect(connectTo, TestPortBase + 10, null, null);
+                IAsyncResult async = socket.BeginConnect(connectTo, port, null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -620,27 +623,27 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void BeginConnectLoopbackToV4Host_Success()
         {
-            DualModeBeginConnect_LoopackDnsToHost_Helper(IPAddress.Loopback, false);
+            DualModeBeginConnect_LoopbackDnsToHost_Helper(IPAddress.Loopback, false, TestPortBase + 90);
         }
 
         [Fact]
         public void BeginConnectLoopbackToV6Host_Success()
         {
-            DualModeBeginConnect_LoopackDnsToHost_Helper(IPAddress.IPv6Loopback, false);
+            DualModeBeginConnect_LoopbackDnsToHost_Helper(IPAddress.IPv6Loopback, false, TestPortBase + 91);
         }
 
         [Fact]
         public void BeginConnectLoopbackToDualHost_Success()
         {
-            DualModeBeginConnect_LoopackDnsToHost_Helper(IPAddress.IPv6Any, true);
+            DualModeBeginConnect_LoopbackDnsToHost_Helper(IPAddress.IPv6Any, true, TestPortBase + 92);
         }
 
-        private void DualModeBeginConnect_LoopackDnsToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginConnect_LoopbackDnsToHost_Helper(IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 11))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                IAsyncResult async = socket.BeginConnect("loopback", TestPortBase + 11, null, null);
+                IAsyncResult async = socket.BeginConnect("localhost", port, null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -653,27 +656,27 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void DualModeSocket_BeginConnectDnsEndPointToV4Host_Success()
         {
-            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.Loopback, false);
+            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.Loopback, false, TestPortBase + 100);
         }
 
         [Fact]
         public void DualModeSocket_BeginConnectDnsEndPointToV6Host_Success()
         {
-            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false);
+            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false, TestPortBase + 101);
         }
 
         [Fact]
         public void DualModeSocket_BeginConnectDnsEndPointToDualHost_Success()
         {
-            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true);
+            DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true, TestPortBase + 102);
         }
 
-        private void DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginConnect_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 50))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
-                IAsyncResult async = socket.BeginConnect(new DnsEndPoint("loopback", TestPortBase + 50), null, null);
+                IAsyncResult async = socket.BeginConnect(new DnsEndPoint("localhost", port), null, null);
                 socket.EndConnect(async);
                 Assert.True(socket.Connected);
             }
@@ -694,7 +697,7 @@ namespace System.Net.Sockets.Tests
             socket.DualMode = false;
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 12);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 110);
             Assert.Throws<NotSupportedException>(() => {
                 socket.ConnectAsync(args);
             });
@@ -703,20 +706,20 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ConnectAsyncV4IPEndPointToV4Host_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 111);
         }
 
         [Fact]
         public void ConnectAsyncV6IPEndPointToV6Host_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 112);
         }
 
         [Fact]
         public void ConnectAsyncV4IPEndPointToV6Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 113);
             });
         }
 
@@ -724,31 +727,31 @@ namespace System.Net.Sockets.Tests
         public void ConnectAsyncV6IPEndPointToV4Host_Fails()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 114);
             });
         }
 
         [Fact]
         public void ConnectAsyncV4IPEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 115);
         }
 
         [Fact]
         public void ConnectAsyncV6IPEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 116);
         }
 
-        private void DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 13))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.Completed += new EventHandler<SocketAsyncEventArgs>(AsyncCompleted);
-                args.RemoteEndPoint = new IPEndPoint(connectTo, TestPortBase + 13);
+                args.RemoteEndPoint = new IPEndPoint(connectTo, port);
                 args.UserToken = waitHandle;
 
                 socket.ConnectAsync(args);
@@ -769,30 +772,30 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToV4Host_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.Loopback, false);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.Loopback, false, TestPortBase + 120);
         }
 
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToV6Host_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false, TestPortBase + 121);
         }
 
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true, TestPortBase + 122);
         }
 
-        private void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 51))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.Completed += new EventHandler<SocketAsyncEventArgs>(AsyncCompleted);
-                args.RemoteEndPoint = new DnsEndPoint("loopback", TestPortBase + 51);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", port);
                 args.UserToken = waitHandle;
 
                 socket.ConnectAsync(args);
@@ -824,7 +827,7 @@ namespace System.Net.Sockets.Tests
             {
                 socket.DualMode = false;
                 Assert.Throws<SocketException>(() => {
-                    socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 14));
+                    socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 130));
                 });
             }
         }
@@ -834,7 +837,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.Loopback.MapToIPv6(), TestPortBase + 15));
+                socket.Bind(new IPEndPoint(IPAddress.Loopback.MapToIPv6(), TestPortBase + 131));
             }
         }
 
@@ -843,7 +846,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 16));
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 132));
             }
         }
 
@@ -852,7 +855,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 17));
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 133));
             }
         }
 
@@ -862,7 +865,7 @@ namespace System.Net.Sockets.Tests
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
                 Assert.Throws<ArgumentException>( () => {
-                    socket.Bind(new DnsEndPoint("loopback", TestPortBase + 52));
+                    socket.Bind(new DnsEndPoint("localhost", TestPortBase + 134));
                 });
             }
         }
@@ -874,7 +877,7 @@ namespace System.Net.Sockets.Tests
             using (Socket serverSocket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
                 serverSocket.DualMode = false;
-                serverSocket.Bind(new IPEndPoint(IPAddress.IPv6Any, TestPortBase + 18));
+                serverSocket.Bind(new IPEndPoint(IPAddress.IPv6Any, TestPortBase + 135));
                 Assert.Throws<SocketException>(() => {
                     serverSocket.DualMode = true;
                 });
@@ -888,32 +891,33 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void AcceptV4BoundToSpecificV4_Success()
         {
-            Accept_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            Accept_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 140);
         }
 
         [Fact]
         public void AcceptV4BoundToAnyV4_Success()
         {
-            Accept_Helper(IPAddress.Any, IPAddress.Loopback);
+            Accept_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 141);
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void AcceptV6BoundToSpecificV6_Success()
         {
-            Accept_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            Accept_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 142);
         }
 
         [Fact]
         public void AcceptV6BoundToAnyV6_Success()
         {
-            Accept_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            Accept_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 143);
         }
 
         [Fact]
         public void AcceptV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                Accept_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                Accept_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 144);
             });
         }
 
@@ -921,7 +925,7 @@ namespace System.Net.Sockets.Tests
         public void AcceptV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                Accept_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                Accept_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 145);
             });
         }
 
@@ -929,23 +933,23 @@ namespace System.Net.Sockets.Tests
         public void AcceptV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                Accept_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                Accept_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 146);
             });
         }
 
         [Fact]
         public void AcceptV4BoundToAnyV6_Success()
         {
-            Accept_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            Accept_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 147);
         }
         
-        private void Accept_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void Accept_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 19));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
                 serverSocket.Listen(1);
-                SocketClient client = new SocketClient(serverSocket, connectTo, TestPortBase + 19);
+                SocketClient client = new SocketClient(serverSocket, connectTo, port);
                 Socket clientSocket = serverSocket.Accept();
                 Assert.True(clientSocket.Connected);
                 Assert.True(clientSocket.DualMode);
@@ -960,32 +964,33 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void BeginAcceptV4BoundToSpecificV4_Success()
         {
-            DualModeConnect_BeginAccept_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            DualModeConnect_BeginAccept_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 150);
         }
 
         [Fact]
         public void BeginAcceptV4BoundToAnyV4_Success()
         {
-            DualModeConnect_BeginAccept_Helper(IPAddress.Any, IPAddress.Loopback);
+            DualModeConnect_BeginAccept_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 151);
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void BeginAcceptV6BoundToSpecificV6_Success()
         {
-            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 152);
         }
 
         [Fact]
         public void BeginAcceptV6BoundToAnyV6_Success()
         {
-            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 153);
         }
 
         [Fact]
         public void BeginAcceptV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_BeginAccept_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                DualModeConnect_BeginAccept_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 154);
             });
         }
 
@@ -993,7 +998,7 @@ namespace System.Net.Sockets.Tests
         public void BeginAcceptV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 155);
             });
         }
 
@@ -1001,24 +1006,24 @@ namespace System.Net.Sockets.Tests
         public void BeginAcceptV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_BeginAccept_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                DualModeConnect_BeginAccept_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 156);
             });
         }
 
         [Fact]
         public void BeginAcceptV4BoundToAnyV6_Success()
         {
-            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 157);
         }
 
-        private void DualModeConnect_BeginAccept_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void DualModeConnect_BeginAccept_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 20));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
                 serverSocket.Listen(1);
                 IAsyncResult async = serverSocket.BeginAccept(null, null);
-                SocketClient client = new SocketClient(serverSocket, connectTo, TestPortBase + 20);
+                SocketClient client = new SocketClient(serverSocket, connectTo, port);
                 Socket clientSocket = serverSocket.EndAccept(async);
                 Assert.True(clientSocket.Connected);
                 Assert.True(clientSocket.DualMode);
@@ -1034,32 +1039,33 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void AcceptAsyncV4BoundToSpecificV4_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 41);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 160);
         }
 
         [Fact]
         public void AcceptAsyncV4BoundToAnyV4_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 42);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 161);
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void AcceptAsyncV6BoundToSpecificV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 43);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 162);
         }
 
         [Fact]
         public void AcceptAsyncV6BoundToAnyV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 44);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 163);
         }
 
         [Fact]
         public void AcceptAsyncV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 45);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 164);
             });
         }
 
@@ -1067,7 +1073,7 @@ namespace System.Net.Sockets.Tests
         public void AcceptAsyncV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 46);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 165);
             });
         }
 
@@ -1075,14 +1081,14 @@ namespace System.Net.Sockets.Tests
         public void AcceptAsyncV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 47);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 166);
             });
         }
 
         [Fact]
         public void AcceptAsyncV4BoundToAnyV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 48);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 167);
         }
 
         private void DualModeConnect_AcceptAsync_Helper(IPAddress listenOn, IPAddress connectTo, int port)
@@ -1142,7 +1148,7 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
             Assert.Throws<SocketException>(() => {
-                socket.SendTo(new byte[1], new IPEndPoint(IPAddress.Loopback, TestPortBase + 40));
+                socket.SendTo(new byte[1], new IPEndPoint(IPAddress.Loopback, TestPortBase + 170));
             });
         }
 
@@ -1152,27 +1158,27 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             Assert.Throws<ArgumentException>(() => {
-                socket.SendTo(new byte[1], new DnsEndPoint("localhost", TestPortBase + 59));
+                socket.SendTo(new byte[1], new DnsEndPoint("localhost", TestPortBase + 171));
             });
         }
         
         [Fact]
         public void SendToV4IPEndPointToV4Host_Success()
         {
-            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 172);
         }
 
         [Fact]
         public void SendToV6IPEndPointToV6Host_Success()
         {
-            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 173);
         }
 
         [Fact]
         public void SendToV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 174);
             });
         }
 
@@ -1180,28 +1186,28 @@ namespace System.Net.Sockets.Tests
         public void SendToV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 175);
             });
         }
 
         [Fact]
         public void SendToV4IPEndPointToDualHost_Success()
         {
-            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 176);
         }
 
         [Fact]
         public void SendToV6IPEndPointToDualHost_Success()
         {
-            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 177);
         }
 
-        private void DualModeSendTo_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeSendTo_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket client = new Socket(SocketType.Dgram, ProtocolType.Udp);
-            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, TestPortBase + 22))
+            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, port))
             {
-                int sent = client.SendTo(new byte[1], new IPEndPoint(connectTo, TestPortBase + 22));
+                int sent = client.SendTo(new byte[1], new IPEndPoint(connectTo, port));
                 Assert.Equal(1, sent); 
 
                 bool success = server.WaitHandle.WaitOne(500); // Make sure the bytes were received
@@ -1224,7 +1230,7 @@ namespace System.Net.Sockets.Tests
             socket.DualMode = false;
 
             Assert.Throws<SocketException>(() => {
-                socket.BeginSendTo(new byte[1], 0, 1, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, TestPortBase + 23),
+                socket.BeginSendTo(new byte[1], 0, 1, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, TestPortBase + 180),
                 null, null);
             });
         }
@@ -1236,27 +1242,27 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
 
             Assert.Throws<ArgumentException>( () => {
-                socket.BeginSendTo(new byte[1], 0, 1, SocketFlags.None, new DnsEndPoint("localhost", TestPortBase + 61), null, null);
+                socket.BeginSendTo(new byte[1], 0, 1, SocketFlags.None, new DnsEndPoint("localhost", TestPortBase + 181), null, null);
             });
         }
 
         [Fact]
         public void BeginSendToV4IPEndPointToV4Host_Success()
         {
-            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 182);
         }
 
         [Fact]
         public void BeginSendToV6IPEndPointToV6Host_Success()
         {
-            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 183);
         }
 
         [Fact]
         public void BeginSendToV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 184);
             });
         }
 
@@ -1264,29 +1270,29 @@ namespace System.Net.Sockets.Tests
         public void BeginSendToV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 185);
             });
         }
 
         [Fact]
         public void BeginSendToV4IPEndPointToDualHost_Success()
         {
-            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 186);
         }
 
         [Fact]
         public void BeginSendToV6IPEndPointToDualHost_Success()
         {
-            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 187);
         }
 
-        private void DualModeBeginSendTo_EndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeBeginSendTo_EndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             Socket client = new Socket(SocketType.Dgram, ProtocolType.Udp);
-            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, TestPortBase + 24))
+            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, port))
             {
                 IAsyncResult async = client.BeginSendTo(new byte[1], 0, 1, SocketFlags.None,
-                    new IPEndPoint(connectTo, TestPortBase + 24), null, null);
+                    new IPEndPoint(connectTo, port), null, null);
                 int sent = client.EndSendTo(async);
                 Assert.Equal(1, sent);
                 bool success = server.WaitHandle.WaitOne(100); // Make sure the bytes were received
@@ -1302,12 +1308,13 @@ namespace System.Net.Sockets.Tests
         #region SendTo Async/Event
 
         [Fact] // Base case
+        [ActiveIssue(DummyErrorMismatchIssue, PlatformID.AnyUnix)]
         public void Socket_SendToAsyncV4IPEndPointToV4Host_Throws()
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 25);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 190);
             args.SetBuffer(new byte[1], 0, 1);
             bool async = socket.SendToAsync(args);
             Assert.False(async);
@@ -1320,7 +1327,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 53);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 191);
             args.SetBuffer(new byte[1], 0, 1);
 
             Assert.Throws<ArgumentException>(() => {
@@ -1331,20 +1338,20 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void SendToAsyncV4IPEndPointToV4Host_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 192);
         }
 
         [Fact]
         public void SendToAsyncV6IPEndPointToV6Host_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 193);
         }
 
         [Fact]
         public void SendToAsyncV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 194);
             });
         }
 
@@ -1352,30 +1359,30 @@ namespace System.Net.Sockets.Tests
         public void SendToAsyncV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 195);
             });
         }
 
         [Fact]
         public void SendToAsyncV4IPEndPointToDualHost_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 196);
         }
 
         [Fact]
         public void SendToAsyncV6IPEndPointToDualHost_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 197);
         }
 
-        private void DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             ManualResetEvent waitHandle = new ManualResetEvent(false);
             Socket client = new Socket(SocketType.Dgram, ProtocolType.Udp);
-            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, TestPortBase + 26))
+            using (SocketUdpServer server = new SocketUdpServer(listenOn, dualModeServer, port))
             {
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(connectTo, TestPortBase + 26);
+                args.RemoteEndPoint = new IPEndPoint(connectTo, port);
                 args.SetBuffer(new byte[1], 0, 1);
                 args.UserToken = waitHandle;
                 args.Completed += AsyncCompleted;
@@ -1413,7 +1420,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
-            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 27);
+            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 200);
             Assert.Throws<ArgumentException>(() => {
                 int received = socket.ReceiveFrom(new byte[1], ref receivedFrom);
             });
@@ -1425,8 +1432,8 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 54, AddressFamily.InterNetworkV6);
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 54));
+                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 201, AddressFamily.InterNetworkV6);
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 201));
                 Assert.Throws<ArgumentException>(() => {
                     int received = socket.ReceiveFrom(new byte[1], ref receivedFrom);
                 });
@@ -1436,40 +1443,41 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ReceiveFromV4BoundToSpecificV4_Success()
         {
-            ReceiveFrom_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            ReceiveFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 202);
         }
 
         [Fact]
         public void ReceiveFromV4BoundToAnyV4_Success()
         {
-            ReceiveFrom_Helper(IPAddress.Any, IPAddress.Loopback);
+            ReceiveFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 203);
         }
 
         [Fact]
         public void ReceiveFromV6BoundToSpecificV6_Success()
         {
-            ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 204);
         }
 
         [Fact]
         public void ReceiveFromV6BoundToAnyV6_Success()
         {
-            ReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            ReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 205);
         }
 
         [Fact]
         public void ReceiveFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<SocketException>(() => {
-                ReceiveFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                ReceiveFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 206);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void ReceiveFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<SocketException>( () => { 
-                ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                ReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 207);
             });
         }
 
@@ -1477,25 +1485,25 @@ namespace System.Net.Sockets.Tests
         public void ReceiveFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<SocketException>(() => {
-                ReceiveFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                ReceiveFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 208);
             });
         }
 
         [Fact]
         public void ReceiveFromV4BoundToAnyV6_Success()
         {
-            ReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            ReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 209);
         }
 
-        private void ReceiveFrom_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void ReceiveFrom_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
                 serverSocket.ReceiveTimeout = 500;
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 28));
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 28);
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
 
-                EndPoint receivedFrom = new IPEndPoint(connectTo, TestPortBase + 28);
+                EndPoint receivedFrom = new IPEndPoint(connectTo, port);
                 int received = serverSocket.ReceiveFrom(new byte[1], ref receivedFrom);
 
                 Assert.Equal(1, received);
@@ -1516,7 +1524,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
-            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 29);
+            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 210);
             Assert.Throws<ArgumentException>(() => {
                 socket.BeginReceiveFrom(new byte[1], 0, 1, SocketFlags.None, ref receivedFrom, null, null);
             });
@@ -1528,8 +1536,8 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 55, AddressFamily.InterNetworkV6);
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 55));
+                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 211, AddressFamily.InterNetworkV6);
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 211));
 
                 Assert.Throws<ArgumentException>(() => {
                     socket.BeginReceiveFrom(new byte[1], 0, 1, SocketFlags.None, ref receivedFrom, null, null);
@@ -1540,40 +1548,41 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void BeginReceiveFromV4BoundToSpecificV4_Success()
         {
-            BeginReceiveFrom_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            BeginReceiveFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 212);
         }
 
         [Fact]
         public void BeginReceiveFromV4BoundToAnyV4_Success()
         {
-            BeginReceiveFrom_Helper(IPAddress.Any, IPAddress.Loopback);
+            BeginReceiveFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 213);
         }
 
         [Fact]
         public void BeginReceiveFromV6BoundToSpecificV6_Success()
         {
-            BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 214);
         }
 
         [Fact]
         public void BeginReceiveFromV6BoundToAnyV6_Success()
         {
-            BeginReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            BeginReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 215);
         }
 
         [Fact]
         public void BeginReceiveFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                BeginReceiveFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 216);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void BeginReceiveFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 217);
             });
         }
 
@@ -1581,23 +1590,23 @@ namespace System.Net.Sockets.Tests
         public void BeginReceiveFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                BeginReceiveFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 218);
             });
         }
 
         [Fact]
         public void BeginReceiveFromV4BoundToAnyV6_Success()
         {
-            BeginReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            BeginReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 219);
         }
 
-        private void BeginReceiveFrom_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void BeginReceiveFrom_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
                 serverSocket.ReceiveTimeout = 500;
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 30));
-                EndPoint receivedFrom = new IPEndPoint(connectTo, TestPortBase + 30);
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
+                EndPoint receivedFrom = new IPEndPoint(connectTo, port);
                 IAsyncResult async = serverSocket.BeginReceiveFrom(new byte[1], 0, 1, SocketFlags.None, 
                     ref receivedFrom, null, null);
 
@@ -1605,14 +1614,14 @@ namespace System.Net.Sockets.Tests
                 Assert.Equal(AddressFamily.InterNetworkV6, remoteEndPoint.AddressFamily);
                 Assert.Equal(connectTo.MapToIPv6(), remoteEndPoint.Address);
 
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 30);
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
                 bool success = async.AsyncWaitHandle.WaitOne(500);
                 if (!success)
                 {
                     throw new TimeoutException();
                 }
 
-                receivedFrom = new IPEndPoint(connectTo, TestPortBase + 30);
+                receivedFrom = new IPEndPoint(connectTo, port);
                 int received = serverSocket.EndReceiveFrom(async, ref receivedFrom);
 
                 Assert.Equal(1, received);
@@ -1634,7 +1643,7 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 31);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 220);
             args.SetBuffer(new byte[1], 0, 1);
 
             Assert.Throws<ArgumentException>(() => {
@@ -1648,9 +1657,9 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 56));
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 221));
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 56, AddressFamily.InterNetworkV6);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 221, AddressFamily.InterNetworkV6);
                 args.SetBuffer(new byte[1], 0, 1);
 
                 Assert.Throws<ArgumentException>(() => {
@@ -1662,40 +1671,41 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ReceiveFromAsyncV4BoundToSpecificV4_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 222);
         }
 
         [Fact]
         public void ReceiveFromAsyncV4BoundToAnyV4_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 223);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToSpecificV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 224);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToAnyV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 225);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 226);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 227);
             });
         }
 
@@ -1703,31 +1713,31 @@ namespace System.Net.Sockets.Tests
         public void ReceiveFromAsyncV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 228);
             });
         }
 
         [Fact]
         public void ReceiveFromAsyncV4BoundToAnyV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 229);
         }
 
-        private void ReceiveFromAsync_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void ReceiveFromAsync_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 32));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
 
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(listenOn, TestPortBase + 32);
+                args.RemoteEndPoint = new IPEndPoint(listenOn, port);
                 args.SetBuffer(new byte[1], 0, 1);
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 args.UserToken = waitHandle;
                 args.Completed += AsyncCompleted;
 
                 bool async = serverSocket.ReceiveFromAsync(args);
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 32);
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
                 if (async && !waitHandle.WaitOne(200))
                 {
                     throw new TimeoutException();
@@ -1760,7 +1770,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
-            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 33);
+            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 230);
             SocketFlags socketFlags = SocketFlags.None;
             IPPacketInformation ipPacketInformation;
 
@@ -1776,8 +1786,8 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 60, AddressFamily.InterNetworkV6);
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 60));
+                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 231, AddressFamily.InterNetworkV6);
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 231));
                 SocketFlags socketFlags = SocketFlags.None;
                 IPPacketInformation ipPacketInformation;
 
@@ -1791,52 +1801,53 @@ namespace System.Net.Sockets.Tests
         [Fact] // Base case
         public void ReceiveMessageFromV4BoundToSpecificMappedV4_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, TestPortBase + 232);
         }
 
         [Fact] // Base case
         public void ReceiveMessageFromV4BoundToAnyMappedV4_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback, TestPortBase + 233);
         }
 
         [Fact]
         public void ReceiveMessageFromV4BoundToSpecificV4_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 234);
         }
 
         [Fact]
         public void ReceiveMessageFromV4BoundToAnyV4_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 235);
         }
 
         [Fact]
         public void ReceiveMessageFromV6BoundToSpecificV6_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 236);
         }
 
         [Fact]
         public void ReceiveMessageFromV6BoundToAnyV6_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 237);
         }
 
         [Fact]
         public void ReceiveMessageFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<SocketException>(() => {
-                ReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                ReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 238);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void ReceiveMessageFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<SocketException>(() => {
-                ReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                ReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 239);
             });
         }
 
@@ -1844,24 +1855,24 @@ namespace System.Net.Sockets.Tests
         public void ReceiveMessageFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<SocketException>(() => {
-                ReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                ReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 240);
             });
         }
 
         [Fact]
         public void ReceiveMessageFromV4BoundToAnyV6_Success()
         {
-            ReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            ReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 241);
         }
 
-        private void ReceiveMessageFrom_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void ReceiveMessageFrom_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
                 serverSocket.ReceiveTimeout = 500;
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 34));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
 
-                EndPoint receivedFrom = new IPEndPoint(connectTo, TestPortBase + 34);
+                EndPoint receivedFrom = new IPEndPoint(connectTo, port);
                 SocketFlags socketFlags = SocketFlags.None;
                 IPPacketInformation ipPacketInformation;
                 int received = 0;
@@ -1878,9 +1889,9 @@ namespace System.Net.Sockets.Tests
                     out ipPacketInformation);
                 });
                 
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 34);
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
 
-                receivedFrom = new IPEndPoint(connectTo, TestPortBase + 34);
+                receivedFrom = new IPEndPoint(connectTo, port);
                 socketFlags = SocketFlags.None;
                 received = serverSocket.ReceiveMessageFrom(new byte[1], 0, 1, ref socketFlags, ref receivedFrom,
                     out ipPacketInformation);
@@ -1911,7 +1922,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
-            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 35);
+            EndPoint receivedFrom = new IPEndPoint(IPAddress.Loopback, TestPortBase + 250);
             SocketFlags socketFlags = SocketFlags.None;
 
             Assert.Throws<ArgumentException>(() => {
@@ -1925,8 +1936,8 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 57, AddressFamily.InterNetworkV6);
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 57));
+                EndPoint receivedFrom = new DnsEndPoint("localhost", TestPortBase + 251, AddressFamily.InterNetworkV6);
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 251));
                 SocketFlags socketFlags = SocketFlags.None;
 
                 Assert.Throws<ArgumentException>(() => {
@@ -1938,52 +1949,53 @@ namespace System.Net.Sockets.Tests
         [Fact] // Base case
         public void BeginReceiveMessageFromV4BoundToSpecificMappedV4_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, TestPortBase + 252);
         }
 
         [Fact] // Base case
         public void BeginReceiveMessageFromV4BoundToAnyMappedV4_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback, TestPortBase + 253);
         }
 
         [Fact]
         public void BeginReceiveMessageFromV4BoundToSpecificV4_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 254);
         }
 
         [Fact]
         public void BeginReceiveMessageFromV4BoundToAnyV4_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 255);
         }
 
         [Fact]
         public void BeginReceiveMessageFromV6BoundToSpecificV6_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 256);
         }
 
         [Fact]
         public void BeginReceiveMessageFromV6BoundToAnyV6_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 257);
         }
 
         [Fact]
         public void BeginReceiveMessageFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                BeginReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 258);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                BeginReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 259);
             });
         }
 
@@ -1991,22 +2003,22 @@ namespace System.Net.Sockets.Tests
         public void BeginReceiveMessageFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                BeginReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                BeginReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 260);
             });
         }
 
         [Fact]
         public void BeginReceiveMessageFromV4BoundToAnyV6_Success()
         {
-            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 261);
         }
 
-        private void BeginReceiveMessageFrom_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void BeginReceiveMessageFrom_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 36));
-                EndPoint receivedFrom = new IPEndPoint(connectTo, TestPortBase + 36);
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
+                EndPoint receivedFrom = new IPEndPoint(connectTo, port);
                 SocketFlags socketFlags = SocketFlags.None;
                 IPPacketInformation ipPacketInformation;
                 IAsyncResult async = serverSocket.BeginReceiveMessageFrom(new byte[1], 0, 1, socketFlags,
@@ -2015,13 +2027,13 @@ namespace System.Net.Sockets.Tests
                 Assert.Equal(AddressFamily.InterNetworkV6, remoteEndPoint.AddressFamily);
                 Assert.Equal(connectTo.MapToIPv6(), remoteEndPoint.Address);
 
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 36);
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
                 bool success = async.AsyncWaitHandle.WaitOne(500);
                 if (!success)
                 {
                     throw new TimeoutException();
                 }
-                receivedFrom = new IPEndPoint(connectTo, TestPortBase + 36);
+                receivedFrom = new IPEndPoint(connectTo, port);
                 int received = serverSocket.EndReceiveMessageFrom(async, ref socketFlags, ref receivedFrom, out ipPacketInformation);
 
                 Assert.Equal(1, received);
@@ -2050,7 +2062,7 @@ namespace System.Net.Sockets.Tests
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             socket.DualMode = false;
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 37);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 270);
             args.SetBuffer(new byte[1], 0, 1);
 
             Assert.Throws<ArgumentException>(() => {
@@ -2064,9 +2076,9 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 58));
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 271));
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 58, AddressFamily.InterNetworkV6);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 271, AddressFamily.InterNetworkV6);
                 args.SetBuffer(new byte[1], 0, 1);
 
                 Assert.Throws<ArgumentException>(() => {
@@ -2078,52 +2090,53 @@ namespace System.Net.Sockets.Tests
         [Fact] // Base case
         public void ReceiveMessageFromAsyncV4BoundToSpecificMappedV4_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, TestPortBase + 272);
         }
 
         [Fact] // Base case
         public void ReceiveMessageFromAsyncV4BoundToAnyMappedV4_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback, TestPortBase + 273);
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV4BoundToSpecificV4_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 274);
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV4BoundToAnyV4_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.Any, IPAddress.Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 275);
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV6BoundToSpecificV6_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 276);
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV6BoundToAnyV6_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 277);
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>( () => { 
-                ReceiveMessageFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                ReceiveMessageFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 278);
             });
         }
 
         [Fact]
+        [ActiveIssue(DummyDualModeV6Issue, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveMessageFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                ReceiveMessageFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 279);
             });
         }
 
@@ -2131,25 +2144,25 @@ namespace System.Net.Sockets.Tests
         public void ReceiveMessageFromAsyncV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveMessageFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                ReceiveMessageFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 280);
             });
         }
 
         [Fact]
         public void ReceiveMessageFromAsyncV4BoundToAnyV6_Success()
         {
-            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 281);
         }
 
-        private void ReceiveMessageFromAsync_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void ReceiveMessageFromAsync_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
                 serverSocket.ReceiveTimeout = 500;
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 38));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
 
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(connectTo, TestPortBase + 38);
+                args.RemoteEndPoint = new IPEndPoint(connectTo, port);
                 args.SetBuffer(new byte[1], 0, 1);
                 args.Completed += AsyncCompleted;
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
@@ -2157,7 +2170,7 @@ namespace System.Net.Sockets.Tests
                 bool async = serverSocket.ReceiveMessageFromAsync(args);
                 Assert.True(async);
 
-                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, TestPortBase + 38);
+                SocketUdpClient client = new SocketUdpClient(serverSocket, connectTo, port);
 
                 if (!waitHandle.WaitOne(500))
                 {

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -8,8 +8,10 @@ namespace System.Net.Sockets.Tests
 {
     public class DualMode
     {
-        private const int DummyDualModeV6Issue = 8000;
-        private const int DummyErrorMismatchIssue = 8001;
+        // TODO: These constants are fill-ins for issues that need to be opened
+        //       once this code is merged into corefx/master.
+        private const int DummyDualModeV6Issue = 123456;
+        private const int DummyErrorMismatchIssue = 123457;
 
         private const int TestPortBase = 8200;  // to 8300
         private readonly ITestOutputHelper _log;

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsAsync.cs
@@ -51,6 +51,7 @@ namespace System.Net.Sockets.Tests
         #region Basic Arguments
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Disposed_Throw()
         {
             using (SocketTestServer.SocketTestServerFactory(Server))
@@ -68,6 +69,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullArgs_Throw()
         {
             using (SocketTestServer.SocketTestServerFactory(Server))
@@ -85,6 +87,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NotConnected_Throw()
         {
             Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
@@ -97,6 +100,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullList_Throws()
         {
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => {
@@ -107,18 +111,21 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullElement_Ignored()
         {
             SendPackets((SendPacketsElement)null, 0);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void EmptyList_Ignored()
         {
             SendPackets(new SendPacketsElement[0], SocketError.Success, 0);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SocketAsyncEventArgs_DefaultSendSize_0()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
@@ -130,30 +137,35 @@ namespace System.Net.Sockets.Tests
         #region Buffers
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NormalBuffer_Success()
         {
             SendPackets(new SendPacketsElement(new byte[10]), 10);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NormalBufferRange_Success()
         {
             SendPackets(new SendPacketsElement(new byte[10], 5, 5), 5);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void EmptyBuffer_Ignored()
         {
             SendPackets(new SendPacketsElement(new byte[0]), 0);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferZeroCount_Ignored()
         {
             SendPackets(new SendPacketsElement(new byte[10], 4, 0), 0);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferMixedBuffers_ZeroCountBufferIgnored()
         {
             SendPacketsElement[] elements = new SendPacketsElement[] 
@@ -166,6 +178,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferZeroCountThenNormal_ZeroCountIgnored()
         {
             Assert.True(Capability.IPv6Support());
@@ -218,6 +231,7 @@ namespace System.Net.Sockets.Tests
         #region Files
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_EmptyFileName_Throws()
         {
             Assert.Throws<ArgumentException>(() => {
@@ -226,6 +240,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_BlankFileName_Throws()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -236,6 +251,7 @@ namespace System.Net.Sockets.Tests
         }
         
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_BadCharactersFileName_Throws()
         {
             Assert.Throws<ArgumentException>(() => {
@@ -245,6 +261,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_MissingDirectoryName_Throws()
         {
             Assert.Throws<DirectoryNotFoundException>(() => {
@@ -254,6 +271,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_MissingFile_Throws()
         {
             Assert.Throws<FileNotFoundException>(() => {
@@ -263,24 +281,28 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_File_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName), TestFileSize); // Whole File
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_FileZeroCount_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName, 0, 0), TestFileSize);  // Whole File
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_FilePart_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName, 10, 20), 20);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_FileMultiPart_Success()
         {
             SendPacketsElement[] elements = new SendPacketsElement[] 
@@ -293,6 +315,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_FileLargeOffset_Throws()
         {
             // Length is validated on Send
@@ -300,6 +323,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void SendPacketsElement_FileLargeCount_Throws()
         {
             // Length is validated on Send
@@ -312,6 +336,7 @@ namespace System.Net.Sockets.Tests
         // This test assumes sequential execution of tests and that it is going to be executed after other tests
         // that used Sockets. 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void TestFinalizers()
         {
             // Making several passes through the FReachable list.

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsAsync.cs
@@ -9,6 +9,10 @@ namespace System.Net.Sockets.Tests
 {
     public class SendPacketsAsync
     {
+        // TODO: This is a stand-in for an issue that will need to be filed once this code is
+        //       merged into corefx.
+        private const int DummySendPacketsIssue = 123456;
+
         private const int TestPortBase = 8100;
         private readonly ITestOutputHelper _log;
 
@@ -51,7 +55,7 @@ namespace System.Net.Sockets.Tests
         #region Basic Arguments
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void Disposed_Throw()
         {
             using (SocketTestServer.SocketTestServerFactory(Server))
@@ -69,7 +73,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void NullArgs_Throw()
         {
             using (SocketTestServer.SocketTestServerFactory(Server))
@@ -87,7 +91,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void NotConnected_Throw()
         {
             Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
@@ -100,7 +104,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void NullList_Throws()
         {
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => {
@@ -111,21 +115,21 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void NullElement_Ignored()
         {
             SendPackets((SendPacketsElement)null, 0);
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void EmptyList_Ignored()
         {
             SendPackets(new SendPacketsElement[0], SocketError.Success, 0);
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SocketAsyncEventArgs_DefaultSendSize_0()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
@@ -137,35 +141,35 @@ namespace System.Net.Sockets.Tests
         #region Buffers
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void NormalBuffer_Success()
         {
             SendPackets(new SendPacketsElement(new byte[10]), 10);
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void NormalBufferRange_Success()
         {
             SendPackets(new SendPacketsElement(new byte[10], 5, 5), 5);
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void EmptyBuffer_Ignored()
         {
             SendPackets(new SendPacketsElement(new byte[0]), 0);
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void BufferZeroCount_Ignored()
         {
             SendPackets(new SendPacketsElement(new byte[10], 4, 0), 0);
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void BufferMixedBuffers_ZeroCountBufferIgnored()
         {
             SendPacketsElement[] elements = new SendPacketsElement[] 
@@ -178,7 +182,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void BufferZeroCountThenNormal_ZeroCountIgnored()
         {
             Assert.True(Capability.IPv6Support());
@@ -231,7 +235,7 @@ namespace System.Net.Sockets.Tests
         #region Files
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_EmptyFileName_Throws()
         {
             Assert.Throws<ArgumentException>(() => {
@@ -240,7 +244,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_BlankFileName_Throws()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -251,7 +255,7 @@ namespace System.Net.Sockets.Tests
         }
         
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_BadCharactersFileName_Throws()
         {
             Assert.Throws<ArgumentException>(() => {
@@ -261,7 +265,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_MissingDirectoryName_Throws()
         {
             Assert.Throws<DirectoryNotFoundException>(() => {
@@ -271,7 +275,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_MissingFile_Throws()
         {
             Assert.Throws<FileNotFoundException>(() => {
@@ -281,28 +285,28 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_File_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName), TestFileSize); // Whole File
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_FileZeroCount_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName, 0, 0), TestFileSize);  // Whole File
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_FilePart_Success()
         {
             SendPackets(new SendPacketsElement(TestFileName, 10, 20), 20);
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_FileMultiPart_Success()
         {
             SendPacketsElement[] elements = new SendPacketsElement[] 
@@ -315,7 +319,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_FileLargeOffset_Throws()
         {
             // Length is validated on Send
@@ -323,7 +327,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void SendPacketsElement_FileLargeCount_Throws()
         {
             // Length is validated on Send
@@ -336,7 +340,7 @@ namespace System.Net.Sockets.Tests
         // This test assumes sequential execution of tests and that it is going to be executed after other tests
         // that used Sockets. 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [ActiveIssue(DummySendPacketsIssue, PlatformID.AnyUnix)]
         public void TestFinalizers()
         {
             // Making several passes through the FReachable list.

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsElementTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsElementTest.cs
@@ -7,6 +7,7 @@ namespace System.Net.Sockets.Tests
         #region Buffer
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullBufferCtor_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -15,6 +16,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullBufferCtorWithOffset_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -23,6 +25,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void NullBufferCtorWithEndOfPacket_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -32,6 +35,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void EmptyBufferCtor_Success()
         {
             // Elements with empty Buffers are ignored on Send
@@ -45,6 +49,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorNormal_Success()
         {
             SendPacketsElement element = new SendPacketsElement(new byte[10]);
@@ -57,6 +62,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorNegOffset_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -65,6 +71,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorNegCount_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -73,6 +80,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorLargeOffset_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -81,6 +89,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorLargeCount_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -89,6 +98,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorEndOfBufferTrue_Success()
         {
             SendPacketsElement element = new SendPacketsElement(new byte[10], 2, 8, true);
@@ -101,6 +111,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorEndOfBufferFalse_Success()
         {
             SendPacketsElement element = new SendPacketsElement(new byte[10], 6, 4, false);
@@ -113,6 +124,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorZeroCount_Success()
         {
             // Elements with empty Buffers are ignored on Send
@@ -130,6 +142,7 @@ namespace System.Net.Sockets.Tests
         #region File
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNull_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -138,6 +151,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorEmpty_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -150,6 +164,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorWhiteSpace_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -162,6 +177,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNormal_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -174,6 +190,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorZeroCountLength_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -186,6 +203,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNegOffset_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -194,6 +212,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNegCount_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -204,6 +223,7 @@ namespace System.Net.Sockets.Tests
         // File lengths are validated on send
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorEndOfBufferTrue_Success()
         {
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 2, 8, true);
@@ -215,6 +235,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorEndOfBufferFalse_Success()
         {
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 6, 4, false);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsElementTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendPacketsElementTest.cs
@@ -7,7 +7,6 @@ namespace System.Net.Sockets.Tests
         #region Buffer
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void NullBufferCtor_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -16,7 +15,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void NullBufferCtorWithOffset_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -25,7 +23,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void NullBufferCtorWithEndOfPacket_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -35,7 +32,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void EmptyBufferCtor_Success()
         {
             // Elements with empty Buffers are ignored on Send
@@ -49,7 +45,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorNormal_Success()
         {
             SendPacketsElement element = new SendPacketsElement(new byte[10]);
@@ -62,7 +57,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorNegOffset_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -71,7 +65,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorNegCount_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -80,7 +73,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorLargeOffset_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -89,7 +81,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorLargeCount_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -98,7 +89,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorEndOfBufferTrue_Success()
         {
             SendPacketsElement element = new SendPacketsElement(new byte[10], 2, 8, true);
@@ -111,7 +101,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorEndOfBufferFalse_Success()
         {
             SendPacketsElement element = new SendPacketsElement(new byte[10], 6, 4, false);
@@ -124,7 +113,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void BufferCtorZeroCount_Success()
         {
             // Elements with empty Buffers are ignored on Send
@@ -142,7 +130,6 @@ namespace System.Net.Sockets.Tests
         #region File
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNull_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => {
@@ -151,7 +138,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorEmpty_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -164,7 +150,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorWhiteSpace_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -177,7 +162,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNormal_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -190,7 +174,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorZeroCountLength_Success()
         {
             // An exception will happen on send if this file doesn't exist
@@ -203,7 +186,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNegOffset_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -212,7 +194,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorNegCount_ArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => {
@@ -223,7 +204,6 @@ namespace System.Net.Sockets.Tests
         // File lengths are validated on send
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorEndOfBufferTrue_Success()
         {
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 2, 8, true);
@@ -235,7 +215,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
         public void FileCtorEndOfBufferFalse_Success()
         {
             SendPacketsElement element = new SendPacketsElement("SomeFileName", 6, 4, false);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.APMServer.Tests.csproj
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.APMServer.Tests.csproj
@@ -6,11 +6,12 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{DA4FB750-6D71-495F-B6B9-3029E58F3AC3}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>Linux;OSX;FreeBSD</UnsupportedPlatforms>
+    <UnsupportedPlatforms>OSX;FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+
   <ItemGroup>
     <Compile Include="AcceptAsync.cs" />
     <Compile Include="AgnosticListenerTest.cs" />
@@ -27,6 +28,7 @@
     <Compile Include="SendPacketsElementTest.cs" />
     <Compile Include="TimeoutTest.cs" />
     <Compile Include="UdpClientTest.cs" />
+
     <!-- Common Sockets files -->
     <Compile Include="$(CommonTestPath)\System.Net\Sockets\SocketTestServer.DefaultAPMFactoryConfiguration.cs">
       <Link>SocketCommon\SocketTestServer.DefaultAsyncFactoryConfiguration.cs</Link>
@@ -43,6 +45,7 @@
     <Compile Include="$(CommonTestPath)\System.Net\Sockets\SocketImplementationType.cs">
       <Link>SocketCommon\SocketImplementationType.cs</Link>
     </Compile>
+
     <!-- Common test files -->
     <Compile Include="$(CommonTestPath)\System.Net\TestLogging.cs">
       <Link>Common\System.Net\TestLogging.cs</Link>
@@ -57,6 +60,7 @@
       <Link>Common\System.Net\Capability.Sockets.cs</Link>
     </Compile>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\System.Net.NameResolution\src\System.Net.NameResolution.csproj">
       <Project>{1714448C-211E-48C1-8B7E-4EE667D336A1}</Project>
@@ -67,6 +71,7 @@
       <Name>System.Net.Sockets</Name>
     </ProjectReference>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.AsyncServer.Tests.csproj
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/System.Net.Sockets.AsyncServer.Tests.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{99794DE7-AC2B-400B-B388-511718375437}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>Linux;OSX;FreeBSD</UnsupportedPlatforms>
+    <UnsupportedPlatforms>OSX;FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/TimeoutTest.cs
@@ -6,8 +6,6 @@ namespace System.Net.Sockets.Tests
     {
         private const int TestPortBase = 8110;
 
-        private const int ServerPort = TestPortBase;
-
         [Fact]
         public void GetAndSet_Success()
         {
@@ -33,11 +31,11 @@ namespace System.Net.Sockets.Tests
             {
                 using (Socket remoteSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    localSocket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, ServerPort));
+                    localSocket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase));
                     localSocket.Listen(1);
                     IAsyncResult localAsync = localSocket.BeginAccept(null, null);
 
-                    remoteSocket.Connect(IPAddress.IPv6Loopback, ServerPort);
+                    remoteSocket.Connect(IPAddress.IPv6Loopback, TestPortBase);
 
                     Socket acceptedSocket = localSocket.EndAccept(localAsync);
                     acceptedSocket.ReceiveTimeout = 100;
@@ -59,11 +57,11 @@ namespace System.Net.Sockets.Tests
             {
                 using (Socket remoteSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    localSocket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, ServerPort));
+                    localSocket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 1));
                     localSocket.Listen(1);
                     IAsyncResult localAsync = localSocket.BeginAccept(null, null);
 
-                    remoteSocket.Connect(IPAddress.IPv6Loopback, ServerPort);
+                    remoteSocket.Connect(IPAddress.IPv6Loopback, TestPortBase + 1);
 
                     Socket acceptedSocket = localSocket.EndAccept(localAsync);
                     acceptedSocket.SendTimeout = 100;

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/UdpClientTest.cs
@@ -9,7 +9,7 @@ namespace NCLTest.Sockets
 {
     public class UDPClientTest
     {
-        private const int TestPortBase = 8400;
+        private const int TestPortBase = 8600;
         private ManualResetEvent _waitHandle = new ManualResetEvent(false);
 
         [Fact]

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/project.json
@@ -10,10 +10,7 @@
     "System.IO": "4.0.10-beta-*",
     "System.Net.Primitives": "4.0.10-beta-*",
     
-    "xunit": "2.0.0-beta5-build2785",
-    "xunit.abstractions.netcore": "1.0.0-prerelease",
-    "xunit.assert": "2.0.0-beta5-build2785",
-    "xunit.core.netcore": "1.0.1-prerelease",
+    "xunit": "2.1.0-beta3-*",
     "xunit.netcore.extensions": "1.0.0-prerelease-*"
   },
   "frameworks": {

--- a/src/System.Net.Sockets.Legacy/tests/PerformanceTests/System.Net.Sockets.APM.Performance.Tests.csproj
+++ b/src/System.Net.Sockets.Legacy/tests/PerformanceTests/System.Net.Sockets.APM.Performance.Tests.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{7340F160-F482-468D-AA09-2B6882BCDAD9}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>Linux;OSX;FreeBSD</UnsupportedPlatforms>
+    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
@@ -56,6 +56,18 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System.Net\Capability.Sockets.cs">
       <Link>Common\System.Net\Capability.Sockets.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
+    <Compile Include="$(CommonTestPath)\System.Net\Sockets\Performance\SocketTestMemcmp.Windows.cs">
+      <Link>SocketCommon\SocketTestMemcmp.Windows.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
+    <Compile Include="$(CommonTestPath)\System.Net\Sockets\Performance\SocketTestMemcmp.Unix.cs">
+      <Link>SocketCommon\SocketTestMemcmp.Unix.cs</Link>
     </Compile>
   </ItemGroup>
   

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -47,7 +47,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 12);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase);
             Assert.Throws<NotSupportedException>(() => {
                 socket.ConnectAsync(args);
             });
@@ -56,20 +56,20 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ConnectAsyncV4IPEndPointToV4Host_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 1);
         }
 
         [Fact]
         public void ConnectAsyncV6IPEndPointToV6Host_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 2);
         }
 
         [Fact]
         public void ConnectAsyncV4IPEndPointToV6Host_Fails()
         {
             Assert.Throws<SocketException>( () => {
-                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 3);
             });
         }
 
@@ -77,31 +77,31 @@ namespace System.Net.Sockets.Tests
         public void ConnectAsyncV6IPEndPointToV4Host_Fails()
         {
             Assert.Throws<SocketException> ( () => {
-                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 4);
             });
         }
 
         [Fact]
         public void ConnectAsyncV4IPEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 5);
         }
 
         [Fact]
         public void ConnectAsyncV6IPEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 6);
         }
 
-        private void DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
-            Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 13))
+            using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.Completed += new EventHandler<SocketAsyncEventArgs>(AsyncCompleted);
-                args.RemoteEndPoint = new IPEndPoint(connectTo, TestPortBase + 13);
+                args.RemoteEndPoint = new IPEndPoint(connectTo, port);
                 args.UserToken = waitHandle;
 
                 socket.ConnectAsync(args);
@@ -111,6 +111,7 @@ namespace System.Net.Sockets.Tests
                 {
                     throw new SocketException((int)args.SocketError);
                 }
+                Assert.True(server.WaitHandle.WaitOne(5000), "Timed out while waiting for accept");
                 Assert.True(socket.Connected);
             }
         }
@@ -122,35 +123,36 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToV4Host_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.Loopback, false);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.Loopback, false, TestPortBase + 10);
         }
 
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToV6Host_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false, TestPortBase + 11);
         }
 
         [Fact]
         public void DualModeSocket_ConnectAsyncDnsEndPointToDualHost_Success()
         {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true);
+            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true, TestPortBase + 12);
         }
 
-        private void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        private void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer, int port)
         {
-            Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, TestPortBase + 51))
+            using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            using (SocketServer server = new SocketServer(_log, listenOn, dualModeServer, port))
             {
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.Completed += new EventHandler<SocketAsyncEventArgs>(AsyncCompleted);
-                args.RemoteEndPoint = new DnsEndPoint("loopback", TestPortBase + 51);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", port);
                 args.UserToken = waitHandle;
 
                 socket.ConnectAsync(args);
 
                 waitHandle.WaitOne();
+                Assert.True(server.WaitHandle.WaitOne(5000), "Timed out while waiting for accept");
                 if (args.SocketError != SocketError.Success)
                 {
                     throw new SocketException((int)args.SocketError);
@@ -174,7 +176,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<SocketException>(() => {
                 using (Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 14));
+                    socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 20));
                 }
             });
         }
@@ -184,7 +186,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.Loopback.MapToIPv6(), TestPortBase + 15));
+                socket.Bind(new IPEndPoint(IPAddress.Loopback.MapToIPv6(), TestPortBase + 21));
             }
         }
 
@@ -193,7 +195,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 16));
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, TestPortBase + 22));
             }
         }
 
@@ -202,7 +204,7 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 17));
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 23));
             }
         }
 
@@ -212,7 +214,7 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<ArgumentException>(() => {
                 using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
                 {
-                    socket.Bind(new DnsEndPoint("loopback", TestPortBase + 52));
+                    socket.Bind(new DnsEndPoint("localhost", TestPortBase + 24));
                 }
             });
         }
@@ -224,32 +226,32 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void AcceptAsyncV4BoundToSpecificV4_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 41);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 30);
         }
 
         [Fact]
         public void AcceptAsyncV4BoundToAnyV4_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 42);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 31);
         }
 
         [Fact]
         public void AcceptAsyncV6BoundToSpecificV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 43);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 32);
         }
 
         [Fact]
         public void AcceptAsyncV6BoundToAnyV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 44);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 33);
         }
 
         [Fact]
         public void AcceptAsyncV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 45);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 34);
             });
         }
 
@@ -257,7 +259,7 @@ namespace System.Net.Sockets.Tests
         public void AcceptAsyncV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 46);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 35);
             });
         }
 
@@ -265,14 +267,14 @@ namespace System.Net.Sockets.Tests
         public void AcceptAsyncV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() => {
-                DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 47);
+                DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 36);
             });
         }
 
         [Fact]
         public void AcceptAsyncV4BoundToAnyV6_Success()
         {
-            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 48);
+            DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 37);
         }
 
         private void DualModeConnect_AcceptAsync_Helper(IPAddress listenOn, IPAddress connectTo, int port)
@@ -334,6 +336,7 @@ namespace System.Net.Sockets.Tests
                 Assert.True(clientSocket.Connected);
                 Assert.Equal(AddressFamily.InterNetworkV6, clientSocket.AddressFamily);
                 Assert.Equal(connectTo.MapToIPv6(), ((IPEndPoint)clientSocket.LocalEndPoint).Address);
+                clientSocket.Dispose();
             }
         }
 
@@ -350,11 +353,11 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 25);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 40);
             args.SetBuffer(new byte[1], 0, 1);
             bool async = socket.SendToAsync(args);
             Assert.False(async);
-            Assert.Equal(SocketError.Fault, args.SocketError);
+			Assert.NotEqual(SocketError.Success, args.SocketError);
         }
 
         [Fact] // Base case
@@ -363,7 +366,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 53);
+            args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 41);
             args.SetBuffer(new byte[1], 0, 1);
             Assert.Throws<ArgumentException>(() => {
                 socket.SendToAsync(args);
@@ -373,20 +376,20 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void SendToAsyncV4IPEndPointToV4Host_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false, TestPortBase + 42);
         }
 
         [Fact]
         public void SendToAsyncV6IPEndPointToV6Host_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 43);
         }
 
         [Fact]
         public void SendToAsyncV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false);
+                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, false, TestPortBase + 44);
             });
         }
 
@@ -394,30 +397,30 @@ namespace System.Net.Sockets.Tests
         public void SendToAsyncV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false);
+                DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, false, TestPortBase + 45);
             });
         }
 
         [Fact]
         public void SendToAsyncV4IPEndPointToDualHost_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true, TestPortBase + 46);
         }
 
         [Fact]
         public void SendToAsyncV6IPEndPointToDualHost_Success()
         {
-            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
+            DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true, TestPortBase + 47);
         }
 
-        private void DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer)
+        private void DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress connectTo, IPAddress listenOn, bool dualModeServer, int port)
         {
             ManualResetEvent waitHandle = new ManualResetEvent(false);
             Socket client = new Socket(SocketType.Dgram, ProtocolType.Udp);
-            using (SocketUdpServer server = new SocketUdpServer(_log, listenOn, dualModeServer, TestPortBase + 26))
+            using (SocketUdpServer server = new SocketUdpServer(_log, listenOn, dualModeServer, port))
             {
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(connectTo, TestPortBase + 26);
+                args.RemoteEndPoint = new IPEndPoint(connectTo, port);
                 args.SetBuffer(new byte[1], 0, 1);
                 args.UserToken = waitHandle;
                 args.Completed += AsyncCompleted;
@@ -451,7 +454,7 @@ namespace System.Net.Sockets.Tests
         {
             Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 31);
+            args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, TestPortBase + 50);
             args.SetBuffer(new byte[1], 0, 1);
 
             Assert.Throws<ArgumentException>(() => {
@@ -465,9 +468,9 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket socket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 56));
+                socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, TestPortBase + 51));
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 56, AddressFamily.InterNetworkV6);
+                args.RemoteEndPoint = new DnsEndPoint("localhost", TestPortBase + 51, AddressFamily.InterNetworkV6);
                 args.SetBuffer(new byte[1], 0, 1);
 
                 Assert.Throws<ArgumentException>(() => {
@@ -479,32 +482,32 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void ReceiveFromAsyncV4BoundToSpecificV4_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 52);
         }
 
         [Fact]
         public void ReceiveFromAsyncV4BoundToAnyV4_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 53);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToSpecificV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 54);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToAnyV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 55);
         }
 
         [Fact]
         public void ReceiveFromAsyncV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback);
+                ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.IPv6Loopback, TestPortBase + 56);
             });
         }
 
@@ -512,7 +515,7 @@ namespace System.Net.Sockets.Tests
         public void ReceiveFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback);
+                ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.Loopback, TestPortBase + 57);
             });
         }
 
@@ -520,31 +523,31 @@ namespace System.Net.Sockets.Tests
         public void ReceiveFromAsyncV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() => {
-                ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback);
+                ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.IPv6Loopback, TestPortBase + 58);
             });
         }
 
         [Fact]
         public void ReceiveFromAsyncV4BoundToAnyV6_Success()
         {
-            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
+            ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 59);
         }
 
-        private void ReceiveFromAsync_Helper(IPAddress listenOn, IPAddress connectTo)
+        private void ReceiveFromAsync_Helper(IPAddress listenOn, IPAddress connectTo, int port)
         {
             using (Socket serverSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
             {
-                serverSocket.Bind(new IPEndPoint(listenOn, TestPortBase + 32));
+                serverSocket.Bind(new IPEndPoint(listenOn, port));
 
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-                args.RemoteEndPoint = new IPEndPoint(listenOn, TestPortBase + 32);
+                args.RemoteEndPoint = new IPEndPoint(listenOn, port);
                 args.SetBuffer(new byte[1], 0, 1);
                 ManualResetEvent waitHandle = new ManualResetEvent(false);
                 args.UserToken = waitHandle;
                 args.Completed += AsyncCompleted;
 
                 bool async = serverSocket.ReceiveFromAsync(args);
-                SocketUdpClient client = new SocketUdpClient(_log, serverSocket, connectTo, TestPortBase + 32);
+                SocketUdpClient client = new SocketUdpClient(_log, serverSocket, connectTo, port);
                 if (async && !waitHandle.WaitOne(200))
                 {
                     throw new TimeoutException();
@@ -588,6 +591,7 @@ namespace System.Net.Sockets.Tests
         {
             private readonly ITestOutputHelper _output;
             private Socket server;
+            private Socket accepted;
             private EventWaitHandle waitHandle = new AutoResetEvent(false);
 
             public EventWaitHandle WaitHandle
@@ -625,6 +629,7 @@ namespace System.Net.Sockets.Tests
                     "Accepted: " + e.GetHashCode() + " SocketAsyncEventArgs with manual event " +
                     handle.GetHashCode() + " error: " + e.SocketError);
 
+                accepted = e.AcceptSocket;
                 handle.Set();
             }
 
@@ -633,6 +638,10 @@ namespace System.Net.Sockets.Tests
                 try
                 {
                     server.Dispose();
+                    if (accepted != null)
+                    {
+                        accepted.Dispose();
+                    }
                 }
                 catch (Exception) { }
             }

--- a/src/System.Net.Sockets/tests/PerformanceTests/System.Net.Sockets.Async.Performance.Tests.csproj
+++ b/src/System.Net.Sockets/tests/PerformanceTests/System.Net.Sockets.Async.Performance.Tests.csproj
@@ -53,6 +53,18 @@
       <Link>Common\System.Net\Capability.Sockets.cs</Link>
     </Compile>
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
+    <Compile Include="$(CommonTestPath)\System.Net\Sockets\Performance\SocketTestMemcmp.Windows.cs">
+      <Link>SocketCommon\SocketTestMemcmp.Windows.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
+    <Compile Include="$(CommonTestPath)\System.Net\Sockets\Performance\SocketTestMemcmp.Unix.cs">
+      <Link>SocketCommon\SocketTestMemcmp.Unix.cs</Link>
+    </Compile>
+  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\..\..\System.Net.NameResolution\src\System.Net.NameResolution.csproj">


### PR DESCRIPTION
- Mark Disconnect() and SendPackets() tests as Windows-specific
- Mark a few tests that cover dual-stack semantics with a dummy issue number while the differences are investigated
- Fix port numbers on a multitude of tests to avoid conflicts at runtime
- Make the perf tests runnable on non-Windows platforms.
