### PR TITLE
Address "multiple connect" calls.

### DIFF
--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -300,9 +300,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.listen.cs">
       <Link>Interop\Unix\libc\Interop.listen.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.poll.cs">
-      <Link>Interop\Unix\libc\Interop.poll.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libc\Interop.recv.cs">
       <Link>Interop\Unix\libc\Interop.recv.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -344,6 +344,7 @@
 
   <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
     <Compile Include="System\Net\Sockets\SocketAsyncEngineBackend.Linux.cs" />
+    <Compile Include="System\Net\Sockets\SocketPal.Linux.cs" />
 
     <Compile Include="$(CommonPath)\Interop\Linux\Interop.Libraries.cs">
       <Link>Interop\Linux\Interop.Libraries.cs</Link>
@@ -406,6 +407,7 @@
 
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
     <Compile Include="System\Net\Sockets\SocketAsyncEngineBackend.OSX.cs" />
+    <Compile Include="System\Net\Sockets\SocketPal.OSX.cs" />
 
     <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
       <Link>Interop\OSX\Interop.Libraries.cs</Link>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4812,9 +4812,14 @@ namespace System.Net.Sockets
                 MultipleConnectAsync multipleConnectAsync = null;
                 if (dnsEP.AddressFamily == AddressFamily.Unspecified)
                 {
+// Disable CS0162 and CS0429: Unreachable code detected
+//
+// SuportsMultipleConnectAttempts is a constant; when false, the following lines will trigger CS0162 or CS0429.
+#pragma warning disable 162, 429
                     multipleConnectAsync = SocketPal.SupportsMultipleConnectAttempts ?
                         (MultipleConnectAsync)(new DualSocketMultipleConnectAsync(socketType, protocolType)) :
                         (MultipleConnectAsync)(new MultipleSocketMultipleConnectAsync(socketType, protocolType));
+#pragma warning restore
                 }
                 else
                 {
@@ -6193,7 +6198,7 @@ namespace System.Net.Sockets
 // Disable CS0162: Unreachable code detected
 //
 // SuportsMultipleConnectAttempts is a constant; when false, the following lines will trigger CS0162.
-#pragma warning disable 162
+#pragma warning disable 162, 429
         private static object PostOneBeginConnect(MultipleAddressConnectAsyncResult context)
         {
             IPAddress currentAddressSnapshot = context.addresses[context.index];

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1055,16 +1055,71 @@ namespace System.Net.Sockets
                 throw new NotSupportedException(SR.net_invalidversion);
             }
 
+// Disable CS0162: Unreachable code detected
+//
+// SuportsMultipleConnectAttempts is a constant; when false, the following lines will trigger CS0162.
+#pragma warning disable 162
             Exception lastex = null;
-            foreach (IPAddress address in addresses)
+            if (SocketPal.SupportsMultipleConnectAttempts)
             {
-                if (CanTryAddressFamily(address.AddressFamily))
+                foreach (IPAddress address in addresses)
+                {
+                    if (CanTryAddressFamily(address.AddressFamily))
+                    {
+                        try
+                        {
+                            Connect(new IPEndPoint(address, port));
+                            lastex = null;
+                            break;
+                        }
+                        catch (Exception ex)
+                        {
+                            if (ExceptionCheck.IsFatal(ex)) throw;
+                            lastex = ex;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                EndPoint endpoint = null;
+                foreach (IPAddress address in addresses)
+                {
+                    if (CanTryAddressFamily(address.AddressFamily))
+                    {
+                        Socket attemptSocket = null;
+                        try
+                        {
+                            attemptSocket = new Socket(_addressFamily, _socketType, _protocolType);
+                            if (IsDualMode)
+                            {
+                                attemptSocket.DualMode = true;
+                            }
+
+                            var attemptEndpoint = new IPEndPoint(address, port);
+                            attemptSocket.Connect(attemptEndpoint);
+                            attemptSocket.Dispose();
+                            endpoint = attemptEndpoint;
+                            lastex = null;
+                            break;
+                        }
+                        catch (Exception ex)
+                        {
+                            if (attemptSocket != null)
+                            {
+                                attemptSocket.Dispose();
+                            }
+                            lastex = ex;
+                        }
+                    }
+                }
+
+                if (endpoint != null)
                 {
                     try
                     {
-                        Connect(new IPEndPoint(address, port));
+                        Connect(endpoint);
                         lastex = null;
-                        break;
                     }
                     catch (Exception ex)
                     {
@@ -1073,9 +1128,12 @@ namespace System.Net.Sockets
                     }
                 }
             }
+#pragma warning restore
 
             if (lastex != null)
+            {
                 throw lastex;
+            }
 
             //if we're not connected, then we didn't get a valid ipaddress in the list
             if (!Connected)
@@ -4752,7 +4810,9 @@ namespace System.Net.Sockets
                 MultipleConnectAsync multipleConnectAsync = null;
                 if (dnsEP.AddressFamily == AddressFamily.Unspecified)
                 {
-                    multipleConnectAsync = new MultipleSocketMultipleConnectAsync(socketType, protocolType);
+                    multipleConnectAsync = SocketPal.SupportsMultipleConnectAttempts ?
+                        (MultipleConnectAsync)(new DualSocketMultipleConnectAsync(socketType, protocolType)) :
+                        (MultipleConnectAsync)(new MultipleSocketMultipleConnectAsync(socketType, protocolType));
                 }
                 else
                 {
@@ -6081,7 +6141,7 @@ namespace System.Net.Sockets
             return DoMultipleAddressConnectCallback(PostOneBeginConnect(context), context);
         }
 
-        private class MultipleAddressConnectAsyncResult : ContextAwareResult
+        private sealed class MultipleAddressConnectAsyncResult : ContextAwareResult
         {
             internal MultipleAddressConnectAsyncResult(IPAddress[] addresses, int port, Socket socket, object myState, AsyncCallback myCallBack) :
                 base(socket, myState, myCallBack)
@@ -6095,6 +6155,8 @@ namespace System.Net.Sockets
             internal IPAddress[] addresses;
             internal int index;
             internal int port;
+            internal bool isUserConnectAttempt;
+            internal Socket lastAttemptSocket;
             internal Exception lastException;
 
             internal EndPoint RemoteEndPoint
@@ -6113,6 +6175,10 @@ namespace System.Net.Sockets
             }
         }
 
+// Disable CS0162: Unreachable code detected
+//
+// SuportsMultipleConnectAttempts is a constant; when false, the following lines will trigger CS0162.
+#pragma warning disable 162
         private static object PostOneBeginConnect(MultipleAddressConnectAsyncResult context)
         {
             IPAddress currentAddressSnapshot = context.addresses[context.index];
@@ -6128,8 +6194,23 @@ namespace System.Net.Sockets
                 // MSRC 11081 - Do the necessary security demand
                 context.socket.CheckCacheRemote(ref endPoint, true);
 
-                IAsyncResult connectResult = context.socket.UnsafeBeginConnect(endPoint,
-                    new AsyncCallback(MultipleAddressConnectCallback), context);
+                var asyncCallback = new AsyncCallback(MultipleAddressConnectCallback);
+
+                IAsyncResult connectResult;
+                if (SocketPal.SupportsMultipleConnectAttempts || context.isUserConnectAttempt)
+                {
+                    connectResult = context.socket.UnsafeBeginConnect(endPoint, asyncCallback, context);
+                }
+                else
+                {
+                    context.lastAttemptSocket = new Socket(context.socket._addressFamily, context.socket._socketType, context.socket._protocolType);
+                    if (context.socket.IsDualMode)
+                    {
+                        context.lastAttemptSocket.DualMode = true;
+                    }
+
+                    connectResult = context.lastAttemptSocket.UnsafeBeginConnect(endPoint, asyncCallback, context);
+                }
 
                 if (connectResult.CompletedSynchronously)
                 {
@@ -6139,7 +6220,9 @@ namespace System.Net.Sockets
             catch (Exception exception)
             {
                 if (exception is OutOfMemoryException)
+                {
                     throw;
+                }
 
                 return exception;
             }
@@ -6150,7 +6233,9 @@ namespace System.Net.Sockets
         private static void MultipleAddressConnectCallback(IAsyncResult result)
         {
             if (result.CompletedSynchronously)
+            {
                 return;
+            }
 
             bool invokeCallback = false;
 
@@ -6182,7 +6267,15 @@ namespace System.Net.Sockets
                 {
                     try
                     {
-                        context.socket.EndConnect((IAsyncResult)result);
+                        if (SocketPal.SupportsMultipleConnectAttempts || context.isUserConnectAttempt)
+                        {
+                            context.socket.EndConnect((IAsyncResult)result);
+                        }
+                        else
+                        {
+                            Debug.Assert(context.lastAttemptSocket != null);
+                            context.lastAttemptSocket.EndConnect((IAsyncResult)result);
+                        }
                     }
                     catch (Exception exception)
                     {
@@ -6190,16 +6283,29 @@ namespace System.Net.Sockets
                     }
                 }
 
+                if (!SocketPal.SupportsMultipleConnectAttempts && !context.isUserConnectAttempt && context.lastAttemptSocket != null)
+                {
+                    context.lastAttemptSocket.Dispose();
+                }
+
                 if (ex == null)
                 {
-                    // Don't invoke the callback from here, because we're probably inside
-                    // a catch-all block that would eat exceptions from the callback.
-                    // Instead tell our caller to invoke the callback outside of its catchall.
-                    return true;
+                    if (!SocketPal.SupportsMultipleConnectAttempts && !context.isUserConnectAttempt)
+                    {
+                        context.isUserConnectAttempt = true;
+                        result = PostOneBeginConnect(context);
+                    }
+                    else
+                    {
+                        // Don't invoke the callback from here, because we're probably inside
+                        // a catch-all block that would eat exceptions from the callback.
+                        // Instead tell our caller to invoke the callback outside of its catchall.
+                        return true;
+                    }
                 }
                 else
                 {
-                    if (++context.index >= context.addresses.Length)
+                    if (++context.index >= context.addresses.Length || context.isUserConnectAttempt)
                         throw ex;
 
                     context.lastException = ex;
@@ -6210,6 +6316,7 @@ namespace System.Net.Sockets
             // Don't invoke the callback at all, because we've posted another async connection attempt
             return false;
         }
+#pragma warning restore
 
         internal IAsyncResult BeginMultipleSend(BufferOffsetSize[] buffers, SocketFlags socketFlags, AsyncCallback callback, object state)
         {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Linux.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Linux.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace System.Net.Sockets
+{
+    internal static partial class SocketPal
+    {
+        public const bool SupportsMultipleConnectAttempts = true;
+
+        public static unsafe void PrimeForNextConnectAttempt(int fileDescriptor, int socketAddressLen)
+        {
+            // On Linux, a non-blocking socket that fails a connect() attempt needs to be kicked
+            // with another connect to AF_UNSPEC before further connect() attempts will return
+            // valid errors. Otherwise, further connect() attempts will return ECONNABORTED.
+            
+            var socketAddressBuffer = stackalloc byte[socketAddressLen];
+            var sockAddr = (Interop.libc.sockaddr*)socketAddressBuffer;
+            sockAddr->sa_family = Interop.libc.AF_UNSPEC;
+
+            int err = Interop.libc.connect(fileDescriptor, sockAddr, (uint)socketAddressLen);
+            Debug.Assert(err == 0, "TryCompleteConnect: failed to disassociate socket after failed connect()");
+        }
+    }
+}

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Linux.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Linux.cs
@@ -9,7 +9,7 @@ namespace System.Net.Sockets
     {
         public const bool SupportsMultipleConnectAttempts = true;
 
-        public static unsafe void PrimeForNextConnectAttempt(int fileDescriptor, int socketAddressLen)
+        static unsafe partial void PrimeForNextConnectAttempt(int fileDescriptor, int socketAddressLen)
         {
             // On Linux, a non-blocking socket that fails a connect() attempt needs to be kicked
             // with another connect to AF_UNSPEC before further connect() attempts will return

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.OSX.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.OSX.cs
@@ -8,10 +8,5 @@ namespace System.Net.Sockets
     internal static partial class SocketPal
     {
         public const bool SupportsMultipleConnectAttempts = false;
-
-        public static void PrimeForNextConnectAttempt(int fileDescriptor, int socketAddressLen)
-        {
-            Debug.Fail("This should never be called!");
-        }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.OSX.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.OSX.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace System.Net.Sockets
+{
+    internal static partial class SocketPal
+    {
+        public const bool SupportsMultipleConnectAttempts = false;
+
+        public static void PrimeForNextConnectAttempt(int fileDescriptor, int socketAddressLen)
+        {
+            Debug.Fail("This should never be called!");
+        }
+    }
+}

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -946,6 +946,10 @@ namespace System.Net.Sockets
             return false;
         }
 
+        // This method is used by systems that may need to reset some socket state before
+        // reusing it for another connect attempt (e.g. Linux).
+        static unsafe partial void PrimeForNextConnectAttempt(int fileDescriptor, int socketAddressLen);
+
         public static unsafe bool TryCompleteConnect(int fileDescriptor, int socketAddressLen, out SocketError errorCode)
         {
             int socketErrno;
@@ -973,17 +977,7 @@ namespace System.Net.Sockets
             }
 
             errorCode = GetSocketErrorForErrorCode(socketError);
-
-// Disable CS0162: Unreachable code detected
-//
-// SuportsMultipleConnectAttempts is a constant; when false, the following lines will trigger CS0162.
-#pragma warning disable 162
-            if (SupportsMultipleConnectAttempts)
-            {
-                PrimeForNextConnectAttempt(fileDescriptor, socketAddressLen);
-            }
-#pragma warning restore 162
-
+            PrimeForNextConnectAttempt(fileDescriptor, socketAddressLen);
             return true;
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -17,6 +17,8 @@ namespace System.Net.Sockets
 {
     internal static class SocketPal
     {
+        public const bool SupportsMultipleConnectAttempts = true;
+
         private readonly static int s_protocolInformationSize = Marshal.SizeOf<Interop.Winsock.WSAPROTOCOL_INFO>();
 
         public static int ProtocolInformationSize { get { return s_protocolInformationSize; } }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/_MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/_MultipleConnectAsync.cs
@@ -351,6 +351,17 @@ namespace System.Net.Sockets
 
         protected abstract void OnFail(bool abortive);
 
+        private void OnFailOuter(bool abortive)
+        {
+            OnFail(abortive);
+
+            if (!SocketPal.SupportsMultipleConnectAttempts && _lastAttemptSocket != null)
+            {
+                _lastAttemptSocket.Dispose();
+                _lastAttemptSocket = null;
+            }
+        }
+
         private bool Fail(bool sync, Exception e)
         {
             if (sync)
@@ -367,12 +378,8 @@ namespace System.Net.Sockets
 
         private void SyncFail(Exception e)
         {
-            OnFail(false);
+            OnFailOuter(false);
 
-            if (!SocketPal.SupportsMultipleConnectAttempts && _lastAttemptSocket != null)
-            {
-                _lastAttemptSocket.Dispose();
-            }
             if (internalArgs != null)
             {
                 internalArgs.Dispose();
@@ -391,12 +398,8 @@ namespace System.Net.Sockets
 
         private void AsyncFail(Exception e)
         {
-            OnFail(false);
+            OnFailOuter(false);
 
-            if (!SocketPal.SupportsMultipleConnectAttempts && _lastAttemptSocket != null)
-            {
-                _lastAttemptSocket.Dispose();
-            }
             if (internalArgs != null)
             {
                 internalArgs.Dispose();
@@ -459,12 +462,7 @@ namespace System.Net.Sockets
             // Call this outside the lock because Socket.Close may block
             if (callOnFail)
             {
-                OnFail(true);
-
-                if (!SocketPal.SupportsMultipleConnectAttempts && _lastAttemptSocket != null)
-                {
-                    _lastAttemptSocket.Dispose();
-                }
+                OnFailOuter(true);
             }
         }
 
@@ -562,7 +560,7 @@ namespace System.Net.Sockets
             get
             {
                 Debug.Fail("Should never get here");
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
         }
 
@@ -649,7 +647,7 @@ namespace System.Net.Sockets
             get
             {
                 Debug.Fail("Should never get here");
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/_MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/_MultipleConnectAsync.cs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Disable CS0162: Unreachable code detected
+//
+// There is unreachable code in this file due to the use of SocketPal.SupportsMultipleConnectAttempts.
+#pragma warning disable 162
+
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,11 +23,14 @@ namespace System.Net.Sockets
         protected IPAddress[] addressList;
         protected int nextAddress;
 
+        private Socket _lastAttemptSocket;
+
         private enum State
         {
             NotStarted,
             DnsQuery,
             ConnectAttempt,
+            UserConnectAttempt,
             Completed,
             Canceled,
         }
@@ -30,6 +38,10 @@ namespace System.Net.Sockets
         private State _state;
 
         private object _lockObject = new object();
+
+        protected abstract bool RequiresUserConnectAttempt { get; }
+
+        protected abstract Socket UserSocket { get; }
 
         // Called by Socket to kick off the ConnectAsync process.  We'll complete the user's SAEA
         // when it's done.  Returns true if the operation will be asynchronous, false if it has failed synchronously
@@ -114,7 +126,11 @@ namespace System.Net.Sockets
 
                     internalArgs = new SocketAsyncEventArgs();
                     internalArgs.Completed += InternalConnectCallback;
-                    internalArgs.SetBuffer(userArgs.Buffer, userArgs.Offset, userArgs.Count);
+
+                    if (!RequiresUserConnectAttempt)
+                    {
+                        internalArgs.SetBuffer(userArgs.Buffer, userArgs.Offset, userArgs.Count);
+                    }
 
                     exception = AttemptConnection();
 
@@ -152,14 +168,25 @@ namespace System.Net.Sockets
                     // closed Socket.
                     exception = new SocketException((int)SocketError.OperationAborted);
                 }
-                else
+                else if (_state == State.ConnectAttempt)
                 {
-                    GlobalLog.Assert(_state == State.ConnectAttempt, "MultipleConnectAsync.InternalConnectCallback(): Unexpected object state");
-
                     if (args.SocketError == SocketError.Success)
                     {
-                        // the connection attempt succeeded; go to the completed state.
-                        // the callback will be called outside the lock
+                        if (RequiresUserConnectAttempt)
+                        {
+                            exception = AttemptUserConnection();
+
+                            if (exception == null)
+                            {
+                                // Don't call the callback; we've started a connection attempt on the
+                                // user's socket.
+                                _state = State.UserConnectAttempt;
+                                return;
+                            }
+                        }
+
+                        // The connection attempt succeeded or the user connect attempt failed synchronously; go to the
+                        // completed state. The callback will be called outside the lock.
                         _state = State.Completed;
                     }
                     else if (args.SocketError == SocketError.OperationAborted)
@@ -172,6 +199,13 @@ namespace System.Net.Sockets
                     else
                     {
                         // Try again, if there are more IPAddresses to be had.
+
+                        // If the underlying OS does not support multiple connect attempts
+                        // on the same socket, dispose the socket used for the last attempt.
+                        if (!SocketPal.SupportsMultipleConnectAttempts)
+                        {
+                            _lastAttemptSocket.Dispose();
+                        }
 
                         // Keep track of this because it will be overwritten by AttemptConnection
                         SocketError currentFailure = args.SocketError;
@@ -200,6 +234,28 @@ namespace System.Net.Sockets
                         }
                     }
                 }
+                else
+                {
+                    GlobalLog.Assert(_state == State.UserConnectAttempt, "MultipleConnectAsync.InternalConnectCallback(): Unexpected object state");
+                    GlobalLog.Assert(RequiresUserConnectAttempt, "MultipleConnectAsync.InternalConnectCallback(): State.UserConnectAttempt without RequiresUserConnectAttempt");
+
+                    if (args.SocketError == SocketError.Success)
+                    {
+                        _state = State.Completed;
+                    }
+                    else if (args.SocketError == SocketError.OperationAborted)
+                    {
+                        // The socket was closed while the connect was in progress.  This can happen if the user
+                        // closes the socket, and is equivalent to a call to CancelConnectAsync
+                        exception = new SocketException((int)SocketError.OperationAborted);
+                        _state = State.Canceled;
+                    }
+                    else
+                    {
+                        // The connect attempt on the user's socket failed. Return the corresponding error.
+                        exception = new SocketException((int)args.SocketError);
+                    }
+                }
             }
 
             if (exception == null)
@@ -218,21 +274,56 @@ namespace System.Net.Sockets
         {
             try
             {
-                Socket attemptSocket = null;
-                IPAddress attemptAddress = GetNextAddress(out attemptSocket);
+                IPAddress attemptAddress = GetNextAddress(out _lastAttemptSocket);
 
                 if (attemptAddress == null)
                 {
                     return new SocketException((int)SocketError.NoData);
                 }
 
-                GlobalLog.Assert(attemptSocket != null, "MultipleConnectAsync.AttemptConnection: attemptSocket is null!");
+                GlobalLog.Assert(attemptAddress != null, "MultipleConnectAsync.AttemptConnection: attemptAddress is null!");
 
                 internalArgs.RemoteEndPoint = new IPEndPoint(attemptAddress, endPoint.Port);
 
-                if (!attemptSocket.ConnectAsync(internalArgs))
+                return AttemptConnection(_lastAttemptSocket, internalArgs);
+            }
+            catch (Exception e)
+            {
+                GlobalLog.Assert(!(e is ObjectDisposedException), "MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                return e;
+            }
+        }
+
+        private Exception AttemptUserConnection()
+        {
+            Debug.Assert(!SocketPal.SupportsMultipleConnectAttempts);
+            Debug.Assert(_lastAttemptSocket != null);
+
+            try
+            {
+                _lastAttemptSocket.Dispose();
+
+                // Setup the internal args. RemoteEndpoint should already be correct.
+                internalArgs.SetBuffer(userArgs.Buffer, userArgs.Offset, userArgs.Count);
+
+                return AttemptConnection(UserSocket, internalArgs);
+            }
+            catch (Exception e)
+            {
+                GlobalLog.Assert(!(e is ObjectDisposedException), "MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                return e;
+            }
+        }
+
+        private static Exception AttemptConnection(Socket attemptSocket, SocketAsyncEventArgs args)
+        {
+            try
+            {
+                GlobalLog.Assert(attemptSocket != null, "MultipleConnectAsync.AttemptConnection: attemptSocket is null!");
+
+                if (!attemptSocket.ConnectAsync(args))
                 {
-                    return new SocketException((int)internalArgs.SocketError);
+                    return new SocketException((int)args.SocketError);
                 }
             }
             catch (ObjectDisposedException)
@@ -251,7 +342,7 @@ namespace System.Net.Sockets
 
         protected abstract void OnSucceed();
 
-        protected void Succeed()
+        private void Succeed()
         {
             OnSucceed();
             userArgs.FinishWrapperConnectSuccess(internalArgs.ConnectSocket, internalArgs.BytesTransferred, internalArgs.SocketFlags);
@@ -277,6 +368,11 @@ namespace System.Net.Sockets
         private void SyncFail(Exception e)
         {
             OnFail(false);
+
+            if (!SocketPal.SupportsMultipleConnectAttempts && _lastAttemptSocket != null)
+            {
+                _lastAttemptSocket.Dispose();
+            }
             if (internalArgs != null)
             {
                 internalArgs.Dispose();
@@ -296,6 +392,11 @@ namespace System.Net.Sockets
         private void AsyncFail(Exception e)
         {
             OnFail(false);
+
+            if (!SocketPal.SupportsMultipleConnectAttempts && _lastAttemptSocket != null)
+            {
+                _lastAttemptSocket.Dispose();
+            }
             if (internalArgs != null)
             {
                 internalArgs.Dispose();
@@ -330,10 +431,11 @@ namespace System.Net.Sockets
                             TaskCreationOptions.DenyChildAttach,
                             TaskScheduler.Default);
 
-                    callOnFail = true;
+                        callOnFail = true;
                         break;
 
                     case State.ConnectAttempt:
+                    case State.UserConnectAttempt:
                         // Cancel was called after the Dns query completed, but before we had a connection result to give
                         // to the user.  Closing the sockets will cause any in-progress ConnectAsync call to fail immediately
                         // with OperationAborted, and will cause ObjectDisposedException from any new calls to ConnectAsync
@@ -358,6 +460,11 @@ namespace System.Net.Sockets
             if (callOnFail)
             {
                 OnFail(true);
+
+                if (!SocketPal.SupportsMultipleConnectAttempts && _lastAttemptSocket != null)
+                {
+                    _lastAttemptSocket.Dispose();
+                }
             }
         }
 
@@ -373,10 +480,21 @@ namespace System.Net.Sockets
     // Used when the instance ConnectAsync method is called, or when the DnsEndPoint specified
     // an AddressFamily.  There's only one Socket, and we only try addresses that match its
     // AddressFamily
-    internal class SingleSocketMultipleConnectAsync : MultipleConnectAsync
+    internal sealed class SingleSocketMultipleConnectAsync : MultipleConnectAsync
     {
         private Socket _socket;
         private bool _userSocket;
+
+        protected override bool RequiresUserConnectAttempt { get { return !SocketPal.SupportsMultipleConnectAttempts; } }
+
+        protected override Socket UserSocket
+        {
+            get
+            {
+                Debug.Assert(!SocketPal.SupportsMultipleConnectAttempts);
+                return _socket;
+            }
+        }
 
         public SingleSocketMultipleConnectAsync(Socket socket, bool userSocket)
         {
@@ -386,13 +504,12 @@ namespace System.Net.Sockets
 
         protected override IPAddress GetNextAddress(out Socket attemptSocket)
         {
-            attemptSocket = _socket;
-
             IPAddress rval = null;
             do
             {
                 if (nextAddress >= addressList.Length)
                 {
+                    attemptSocket = null;
                     return null;
                 }
 
@@ -400,6 +517,19 @@ namespace System.Net.Sockets
                 ++nextAddress;
             }
             while (!_socket.CanTryAddressFamily(rval.AddressFamily));
+
+            if (SocketPal.SupportsMultipleConnectAttempts)
+            {
+                attemptSocket = _socket;
+            }
+            else
+            {
+                attemptSocket = new Socket(_socket.AddressFamily, _socket.SocketType, _socket.ProtocolType);
+                if (_socket.AddressFamily == AddressFamily.InterNetworkV6 && _socket.DualMode)
+                {
+                    attemptSocket.DualMode = true;
+                }
+            }
 
             return rval;
         }
@@ -420,13 +550,26 @@ namespace System.Net.Sockets
 
     // This is used when the static ConnectAsync method is called.  We don't know the address family
     // ahead of time, so we create both IPv4 and IPv6 sockets.
-    internal class MultipleSocketMultipleConnectAsync : MultipleConnectAsync
+    internal sealed class DualSocketMultipleConnectAsync : MultipleConnectAsync
     {
         private Socket _socket4;
         private Socket _socket6;
 
-        public MultipleSocketMultipleConnectAsync(SocketType socketType, ProtocolType protocolType)
+        protected override bool RequiresUserConnectAttempt { get { return false; } }
+
+        protected override Socket UserSocket
         {
+            get
+            {
+                Debug.Fail("Should never get here");
+                throw new NotImplementedException();
+            }
+        }
+
+        public DualSocketMultipleConnectAsync(SocketType socketType, ProtocolType protocolType)
+        {
+            Debug.Assert(SocketPal.SupportsMultipleConnectAttempts);
+
             if (Socket.OSSupportsIPv4)
             {
                 _socket4 = new Socket(AddressFamily.InterNetwork, socketType, protocolType);
@@ -490,5 +633,66 @@ namespace System.Net.Sockets
                 _socket6.Dispose();
             }
         }
+    }
+
+    internal sealed class MultipleSocketMultipleConnectAsync : MultipleConnectAsync
+    {
+        private readonly SocketType _socketType;
+        private readonly ProtocolType _protocolType;
+        private readonly bool _supportsIPv4;
+        private readonly bool _supportsIPv6;
+
+        protected override bool RequiresUserConnectAttempt { get { return false; } }
+
+        protected override Socket UserSocket
+        {
+            get
+            {
+                Debug.Fail("Should never get here");
+                throw new NotImplementedException();
+            }
+        }
+
+        public MultipleSocketMultipleConnectAsync(SocketType socketType, ProtocolType protocolType)
+        {
+            Debug.Assert(!SocketPal.SupportsMultipleConnectAttempts);
+
+            _socketType = socketType;
+            _protocolType = protocolType;
+            _supportsIPv4 = Socket.OSSupportsIPv4;
+            _supportsIPv6 = Socket.OSSupportsIPv6;
+        }
+
+        protected override IPAddress GetNextAddress(out Socket attemptSocket)
+        {
+            if (_supportsIPv4 || _supportsIPv6)
+            {
+                while (nextAddress < addressList.Length)
+                {
+                    IPAddress rval = addressList[nextAddress];
+                    ++nextAddress;
+
+                    if (_supportsIPv6 && rval.AddressFamily == AddressFamily.InterNetworkV6)
+                    {
+                        attemptSocket = new Socket(AddressFamily.InterNetworkV6, _socketType, _protocolType);
+                        return rval;
+                    }
+                    else if (_supportsIPv4 && rval.AddressFamily == AddressFamily.InterNetwork)
+                    {
+                        attemptSocket = new Socket(AddressFamily.InterNetwork, _socketType, _protocolType);
+                        return rval;
+                    }
+                }
+            }
+
+            attemptSocket = null;
+            return null;
+        }
+
+        // nothing to do on failure
+        protected override void OnFail(bool abortive) { }
+
+        // nothing to do on success
+        protected override void OnSucceed() { }
     }
 }


### PR DESCRIPTION
- Support "multiple connect" operations (e.g. Connect(IPAddress[]), DnsEndPoint connections,
  etc.) on platforms that do not support multiple calls to connect() on the same socket.
  For these platforms, each address will be tried on a new socket. Once a good address is
  found (if any), the user's socket will attempt to connect to that address.
