### PR TITLE
Fix bugs in S.N.Sockets on *nix.

### DIFF
--- a/src/Common/src/Interop/Linux/libc/Interop.SocketOptionName.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.SocketOptionName.cs
@@ -40,6 +40,7 @@ internal static partial class Interop
 
         public const int IPV6_V6ONLY = 26;
         public const int IPV6_RECVPKTINFO = 49;
+        public const int IPV6_PKTINFO = 50;
 
         public const int TCP_NODELAY = 1;
     }

--- a/src/Common/src/Interop/Linux/libc/Interop.cmsghdr.cs
+++ b/src/Common/src/Interop/Linux/libc/Interop.cmsghdr.cs
@@ -10,12 +10,9 @@ internal static partial class Interop
 #pragma warning disable 169, 649
         public unsafe struct cmsghdr
         {
-            public static int Size { get { return sizeof(cmsghdr) - 1; } }
-
             public IntPtr cmsg_len;
             public int cmsg_level;
             public int cmsg_type;
-            public byte cmsg_data; // Actually variably-sized
         }
 #pragma warning restore 169, 649
     }

--- a/src/Common/src/Interop/OSX/libc/Interop.SocketOptionName.cs
+++ b/src/Common/src/Interop/OSX/libc/Interop.SocketOptionName.cs
@@ -39,6 +39,7 @@ internal static partial class Interop
 
         public const int IPV6_V6ONLY = 27;
         public const int IPV6_RECVPKTINFO = 61;
+        public const int IPV6_PKTINFO = 46;
 
         public const int TCP_NODELAY = 0x1;
     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -114,6 +114,8 @@ namespace System.Net.Sockets
             _socketType = socketType;
             _protocolType = protocolType;
 
+            Debug.Assert(addressFamily != AddressFamily.InterNetworkV6 || !DualMode);
+
             if (s_LoggingEnabled) Logging.Exit(Logging.Sockets, this, "Socket", null);
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -283,7 +283,6 @@ namespace System.Net.Sockets
             {
                 get
                 {
-                    Debug.Assert(!IsStopped);
                     return (TOperation)_tail;
                 }
             }
@@ -354,6 +353,7 @@ namespace System.Net.Sockets
 
             if (_registeredEvents == SocketAsyncEvents.None)
             {
+                Debug.Assert(!_handle.IsAllocated);
                 _handle = GCHandle.Alloc(this, GCHandleType.Normal);
             }
 
@@ -375,20 +375,26 @@ namespace System.Net.Sockets
         private void UnregisterRead()
         {
             Debug.Assert(Monitor.IsEntered(_queueLock));
-            Debug.Assert(_registeredEvents == (SocketAsyncEvents.Read | SocketAsyncEvents.Write));
+            Debug.Assert((_registeredEvents & SocketAsyncEvents.Read) != SocketAsyncEvents.None);
 
             SocketAsyncEvents events = _registeredEvents & ~SocketAsyncEvents.Read;
-
-            Interop.Error errorCode;
-            bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode);
-
-            if (unregistered || errorCode == Interop.Error.EBADF)
+            if (events == SocketAsyncEvents.None)
             {
-                _registeredEvents = events;
+                Unregister();
             }
             else
             {
-                Debug.Fail(string.Format("UnregisterRead failed: {0}", errorCode));
+                Interop.Error errorCode;
+                bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode);
+
+                if (unregistered)
+                {
+                    _registeredEvents = events;
+                }
+                else
+                {
+                    Debug.Fail(string.Format("UnregisterRead failed: {0}", errorCode));
+                }
             }
         }
 
@@ -406,7 +412,13 @@ namespace System.Net.Sockets
             bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, SocketAsyncEvents.None, _handle, out errorCode);
             _registeredEvents = (SocketAsyncEvents)(-1);
 
-            if (unregistered || errorCode == Interop.Error.EBADF)
+            // We may receive any of the errors below if _fileDescriptor has already been closed.
+            unregistered = unregistered ||
+                errorCode == Interop.Error.EBADF ||
+                errorCode == Interop.Error.ENOENT ||
+                errorCode == Interop.Error.EPERM;
+
+            if (unregistered)
             {
                 _registeredEvents = SocketAsyncEvents.None;
                 _handle.Free();
@@ -417,7 +429,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private void ProcessClose()
+        private void CloseInner()
         {
             Debug.Assert(Monitor.IsEntered(_closeLock) && !Monitor.IsEntered(_queueLock));
 
@@ -438,37 +450,35 @@ namespace System.Net.Sockets
                 // TODO: assert that queues are all empty if _registeredEvents was SocketAsyncEvents.None?
             }
 
-            if (!acceptOrConnectQueue.IsStopped)
+            // TODO: the error codes on these operations may need to be changed to account for
+            //       the close. I think Winsock returns OperationAborted in the case that
+            //       the socket for an outstanding operation is closed.
+
+            Debug.Assert(!acceptOrConnectQueue.IsStopped || acceptOrConnectQueue.IsEmpty);
+            while (!acceptOrConnectQueue.IsEmpty)
             {
-                while (!acceptOrConnectQueue.IsEmpty)
-                {
-                    AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
-                    bool completed = op.TryCompleteAsync(_fileDescriptor);
-                    Debug.Assert(completed);
-                    acceptOrConnectQueue.Dequeue();
-                }
+                AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
+                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                Debug.Assert(completed);
+                acceptOrConnectQueue.Dequeue();
             }
 
-            if (!sendQueue.IsStopped)
+            Debug.Assert(!sendQueue.IsStopped || sendQueue.IsEmpty);
+            while (!sendQueue.IsEmpty)
             {
-                while (!sendQueue.IsEmpty)
-                {
-                    SendReceiveOperation op = sendQueue.Head;
-                    bool completed = op.TryCompleteAsync(_fileDescriptor);
-                    Debug.Assert(completed);
-                    sendQueue.Dequeue();
-                }
+                SendReceiveOperation op = sendQueue.Head;
+                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                Debug.Assert(completed);
+                sendQueue.Dequeue();
             }
 
-            if (!receiveQueue.IsStopped)
+            Debug.Assert(!receiveQueue.IsStopped || receiveQueue.IsEmpty);
+            while (!receiveQueue.IsEmpty)
             {
-                while (!receiveQueue.IsEmpty)
-                {
-                    TransferOperation op = receiveQueue.Head;
-                    bool completed = op.TryCompleteAsync(_fileDescriptor);
-                    Debug.Assert(completed);
-                    receiveQueue.Dequeue();
-                }
+                TransferOperation op = receiveQueue.Head;
+                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                Debug.Assert(completed);
+                receiveQueue.Dequeue();
             }
         }
 
@@ -478,7 +488,7 @@ namespace System.Net.Sockets
 
             lock (_closeLock)
             {
-                ProcessClose();
+                CloseInner();
             }
         }
 
@@ -1287,7 +1297,7 @@ namespace System.Net.Sockets
                 if ((events & SocketAsyncEvents.Close) != 0)
                 {
                     // Drain queues and unregister this fd, then return.
-                    ProcessClose();
+                    CloseInner();
                     return;
                 }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -798,7 +798,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _receiveQueue, operation, SocketAsyncEvents.Write, out isStopped))
+            while (!TryBeginOperation(ref _receiveQueue, operation, SocketAsyncEvents.Read, out isStopped))
             {
                 if (isStopped)
                 {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -423,28 +423,37 @@ namespace System.Net.Sockets
                 // TODO: assert that queues are all empty if _registeredEvents was SocketAsyncEvents.None?
             }
 
-            while (!acceptOrConnectQueue.IsEmpty)
+            if (!acceptOrConnectQueue.IsStopped)
             {
-                AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor);
-                Debug.Assert(completed);
-                acceptOrConnectQueue.Dequeue();
+                while (!acceptOrConnectQueue.IsEmpty)
+                {
+                    AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
+                    bool completed = op.TryCompleteAsync(_fileDescriptor);
+                    Debug.Assert(completed);
+                    acceptOrConnectQueue.Dequeue();
+                }
             }
 
-            while (!sendQueue.IsEmpty)
+            if (!sendQueue.IsStopped)
             {
-                SendReceiveOperation op = sendQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor);
-                Debug.Assert(completed);
-                sendQueue.Dequeue();
+                while (!sendQueue.IsEmpty)
+                {
+                    SendReceiveOperation op = sendQueue.Head;
+                    bool completed = op.TryCompleteAsync(_fileDescriptor);
+                    Debug.Assert(completed);
+                    sendQueue.Dequeue();
+                }
             }
 
-            while (!receiveQueue.IsEmpty)
+            if (!receiveQueue.IsStopped)
             {
-                TransferOperation op = receiveQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor);
-                Debug.Assert(completed);
-                receiveQueue.Dequeue();
+                while (!receiveQueue.IsEmpty)
+                {
+                    TransferOperation op = receiveQueue.Head;
+                    bool completed = op.TryCompleteAsync(_fileDescriptor);
+                    Debug.Assert(completed);
+                    receiveQueue.Dequeue();
+                }
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -346,26 +346,30 @@ namespace System.Net.Sockets
             _engine = engine;
         }
 
-        private void Register()
+        private void Register(SocketAsyncEvents events)
         {
             Debug.Assert(Monitor.IsEntered(_queueLock));
-            Debug.Assert(!_handle.IsAllocated);
-            Debug.Assert(_registeredEvents == SocketAsyncEvents.None);
+            Debug.Assert(!_handle.IsAllocated || _registeredEvents != SocketAsyncEvents.None);
+            Debug.Assert((_registeredEvents & events) == SocketAsyncEvents.None);
 
-            _handle = GCHandle.Alloc(this, GCHandleType.Normal);
-
-            const SocketAsyncEvents Events = SocketAsyncEvents.Read | SocketAsyncEvents.Write;
+            if (_registeredEvents == SocketAsyncEvents.None)
+            {
+                _handle = GCHandle.Alloc(this, GCHandleType.Normal);
+            }
 
             Interop.Error errorCode;
-            if (!_engine.TryRegister(_fileDescriptor, SocketAsyncEvents.None, Events, _handle, out errorCode))
+            if (!_engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode))
             {
-                _handle.Free();
+                if (_registeredEvents == SocketAsyncEvents.None)
+                {
+                    _handle.Free();
+                }
 
                 // TODO: throw an appropiate exception
                 throw new Exception(string.Format("SocketAsyncContext.Register: {0}", errorCode));
             }
 
-            _registeredEvents = Events;
+            _registeredEvents |= events;
         }
 
         private void UnregisterRead()
@@ -377,8 +381,15 @@ namespace System.Net.Sockets
 
             Interop.Error errorCode;
             bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode);
-            Debug.Assert(unregistered, string.Format("UnregisterRead failed: {0}", errorCode));
-            _registeredEvents = events;
+
+            if (unregistered || errorCode == Interop.Error.EBADF)
+            {
+                _registeredEvents = events;
+            }
+            else
+            {
+                Debug.Fail(string.Format("UnregisterRead failed: {0}", errorCode));
+            }
         }
 
         private void Unregister()
@@ -399,6 +410,10 @@ namespace System.Net.Sockets
             {
                 _registeredEvents = SocketAsyncEvents.None;
                 _handle.Free();
+            }
+            else
+            {
+                Debug.Fail(string.Format("Unregister failed: {0}", errorCode));
             }
         }
 
@@ -467,7 +482,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private bool TryBeginOperation<TOperation>(ref OperationQueue<TOperation> queue, TOperation operation, out bool isStopped)
+        private bool TryBeginOperation<TOperation>(ref OperationQueue<TOperation> queue, TOperation operation, SocketAsyncEvents events, out bool isStopped)
             where TOperation : AsyncOperation
         {
             lock (_queueLock)
@@ -487,9 +502,9 @@ namespace System.Net.Sockets
                         return false;
                 }
 
-                if (_registeredEvents == SocketAsyncEvents.None)
+                if ((_registeredEvents & events) == SocketAsyncEvents.None)
                 {
-                    Register();
+                    Register(events);
                 }
 
                 queue.Enqueue(operation);
@@ -530,7 +545,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, out isStopped))
+                while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, SocketAsyncEvents.Read, out isStopped))
                 {
                     if (isStopped)
                     {
@@ -587,7 +602,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, out isStopped))
+            while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, SocketAsyncEvents.Read, out isStopped))
             {
                 if (isStopped)
                 {
@@ -627,7 +642,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, out isStopped))
+                while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, SocketAsyncEvents.Write, out isStopped))
                 {
                     if (isStopped)
                     {
@@ -668,7 +683,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, out isStopped))
+            while (!TryBeginOperation(ref _acceptOrConnectQueue, operation, SocketAsyncEvents.Write, out isStopped))
             {
                 if (isStopped)
                 {
@@ -725,7 +740,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+                while (!TryBeginOperation(ref _receiveQueue, operation, SocketAsyncEvents.Read, out isStopped))
                 {
                     if (isStopped)
                     {
@@ -783,7 +798,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+            while (!TryBeginOperation(ref _receiveQueue, operation, SocketAsyncEvents.Write, out isStopped))
             {
                 if (isStopped)
                 {
@@ -837,7 +852,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+                while (!TryBeginOperation(ref _receiveQueue, operation, SocketAsyncEvents.Read, out isStopped))
                 {
                     if (isStopped)
                     {
@@ -893,7 +908,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+            while (!TryBeginOperation(ref _receiveQueue, operation, SocketAsyncEvents.Read, out isStopped))
             {
                 if (isStopped)
                 {
@@ -942,7 +957,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+                while (!TryBeginOperation(ref _receiveQueue, operation, SocketAsyncEvents.Read, out isStopped))
                 {
                     if (isStopped)
                     {
@@ -1008,7 +1023,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _receiveQueue, operation, out isStopped))
+            while (!TryBeginOperation(ref _receiveQueue, operation, SocketAsyncEvents.Read, out isStopped))
             {
                 if (isStopped)
                 {
@@ -1062,7 +1077,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _sendQueue, operation, out isStopped))
+                while (!TryBeginOperation(ref _sendQueue, operation, SocketAsyncEvents.Write, out isStopped))
                 {
                     if (isStopped)
                     {
@@ -1113,7 +1128,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _sendQueue, operation, out isStopped))
+            while (!TryBeginOperation(ref _sendQueue, operation, SocketAsyncEvents.Write, out isStopped))
             {
                 if (isStopped)
                 {
@@ -1169,7 +1184,7 @@ namespace System.Net.Sockets
                 };
 
                 bool isStopped;
-                while (!TryBeginOperation(ref _sendQueue, operation, out isStopped))
+                while (!TryBeginOperation(ref _sendQueue, operation, SocketAsyncEvents.Write, out isStopped))
                 {
                     if (isStopped)
                     {
@@ -1222,7 +1237,7 @@ namespace System.Net.Sockets
             };
 
             bool isStopped;
-            while (!TryBeginOperation(ref _sendQueue, operation, out isStopped))
+            while (!TryBeginOperation(ref _sendQueue, operation, SocketAsyncEvents.Write, out isStopped))
             {
                 if (isStopped)
                 {
@@ -1243,7 +1258,7 @@ namespace System.Net.Sockets
 
         public unsafe void HandleEvents(SocketAsyncEvents events)
         {
-            Debug.Assert(!Monitor.IsEntered(_queueLock) || Monitor.IsEntered(_closeLock));
+            Debug.Assert(!Monitor.IsEntered(_queueLock) || Monitor.IsEntered(_closeLock), "Lock ordering violation");
 
             lock (_closeLock)
             {
@@ -1253,9 +1268,9 @@ namespace System.Net.Sockets
                     // Retry the unregistration.
                     lock (_queueLock)
                     {
-                        Debug.Assert(_acceptOrConnectQueue.IsStopped);
-                        Debug.Assert(_sendQueue.IsStopped);
-                        Debug.Assert(_receiveQueue.IsStopped);
+                        Debug.Assert(_acceptOrConnectQueue.IsStopped, "{Accept,Connect} queue should be stopped before retrying unregistration");
+                        Debug.Assert(_sendQueue.IsStopped, "Send queue should be stopped before retrying unregistration");
+                        Debug.Assert(_receiveQueue.IsStopped, "Receive queue should be stopped before retrying unregistration");
 
                         Unregister();
                         return;
@@ -1279,7 +1294,7 @@ namespace System.Net.Sockets
                 if ((events & SocketAsyncEvents.ReadClose) != 0)
                 {
                     // Drain read queue and unregister read operations
-                    Debug.Assert(_acceptOrConnectQueue.IsEmpty);
+                    Debug.Assert(_acceptOrConnectQueue.IsEmpty, "{Accept,Connect} queue should be empty before ReadClose");
 
                     OperationQueue<TransferOperation> receiveQueue;
                     lock (_queueLock)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.Linux.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.Linux.cs
@@ -85,7 +85,10 @@ namespace System.Net.Sockets
 
                     var handle = (GCHandle)events[i].data;
                     var context = (SocketAsyncContext)handle.Target;
-                    context.HandleEvents(GetSocketAsyncEvents(evts));
+                    if (context != null)
+                    {
+                        context.HandleEvents(GetSocketAsyncEvents(evts));
+                    }
                 }
             }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.Linux.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.Linux.cs
@@ -72,9 +72,20 @@ namespace System.Net.Sockets
 
                 for (int i = 0; i < numEvents; i++)
                 {
+                    uint evts = events[i].events;
+
+                    // epoll does not play well with disconnected connection-oriented sockets, frequently
+                    // reporting spurious EPOLLHUP events. Fortunately, EPOLLHUP may be handled as an
+                    // EPOLLIN | EPOLLOUT event: the usual processing for these events will recognize and
+                    // handle the HUP condition.
+                    if ((evts & Interop.libc.EPOLLHUP) != 0)
+                    {
+                        evts = (evts & ~Interop.libc.EPOLLHUP) | Interop.libc.EPOLLIN | Interop.libc.EPOLLOUT;
+                    }
+
                     var handle = (GCHandle)events[i].data;
                     var context = (SocketAsyncContext)handle.Target;
-                    context.HandleEvents(GetSocketAsyncEvents(events[i].events));
+                    context.HandleEvents(GetSocketAsyncEvents(evts));
                 }
             }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.OSX.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.OSX.cs
@@ -87,7 +87,11 @@ namespace System.Net.Sockets
                 {
                     var handle = (GCHandle)(IntPtr)events[i].udata;
                     var context = (SocketAsyncContext)handle.Target;
-                    context.HandleEvents(GetSocketAsyncEvents(events[i].filter, events[i].flags));
+
+                    if (context != null)
+                    {
+                        context.HandleEvents(GetSocketAsyncEvents(events[i].filter, events[i].flags));
+                    }
                 }
             }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.OSX.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngineBackend.OSX.cs
@@ -45,9 +45,14 @@ namespace System.Net.Sockets
 
                 case Interop.libc.EVFILT_WRITE:
                     events = SocketAsyncEvents.Write;
+
+                    // kqueue does not play well with disconnected connection-oriented sockets, frequently
+                    // reporting spurious EOF events. Fortunately, EOF may be handled as an EVFILT_READ |
+                    // EVFILT_WRITE event: the usual processing for these events will recognize and
+                    // handle the EOF condition.
                     if ((flags & Interop.libc.EV_EOF) != 0)
                     {
-                        events |= SocketAsyncEvents.Close;
+                        events |= SocketAsyncEvents.Read;
                     }
                     break;
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -255,7 +255,7 @@ namespace System.Net.Sockets
 
         private SocketError FinishOperationAccept(Internals.SocketAddress remoteSocketAddress)
         {
-            System.Buffer.BlockCopy(m_AcceptBuffer, 0, remoteSocketAddress.Buffer, 0, _socketAddressSize);
+            System.Buffer.BlockCopy(m_AcceptBuffer, 0, remoteSocketAddress.Buffer, 0, m_AcceptAddressBufferCount);
             m_AcceptSocket = _currentSocket.CreateAcceptSocket(
                 SafeCloseSocket.CreateSocket(_acceptedFileDescriptor),
                 _currentSocket.m_RightEndPoint.Create(remoteSocketAddress));


### PR DESCRIPTION
- Address most remaining issues with S.N.Sockets on Linux
  - There are some differences in dual-mode semantics and error codes that are as of yet unresolved.
- Address a few bugs on OS X, mostly w.r.t. kqueue event registration.
