### PR TITLE
*nix fixes.

### DIFF
--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -109,6 +109,11 @@ namespace System.Net.Sockets
             {
                 int errorCode;
 
+                if (_asyncContext != null)
+                {
+                    _asyncContext.Close();
+                }
+
                 // If m_Blockable was set in BlockingRelease, it's safe to block here, which means
                 // we can honor the linger options set on the socket.  It also means closesocket() might return WSAEWOULDBLOCK, in which
                 // case we need to do some recovery.
@@ -190,10 +195,6 @@ namespace System.Net.Sockets
 #endif
                 GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close#3():" + (errorCode == -1 ? (int)Interop.Sys.GetLastError() : errorCode).ToString());
 
-                if (errorCode == 0 && _asyncContext != null)
-                {
-                    _asyncContext.Close();
-                }
                 return SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
             }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -459,7 +459,7 @@ namespace System.Net.Sockets
             while (!acceptOrConnectQueue.IsEmpty)
             {
                 AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor, true);
+                bool completed = op.TryCompleteAsync(_fileDescriptor, forceComplete: true);
                 Debug.Assert(completed);
                 acceptOrConnectQueue.Dequeue();
             }
@@ -468,7 +468,7 @@ namespace System.Net.Sockets
             while (!sendQueue.IsEmpty)
             {
                 SendReceiveOperation op = sendQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor, true);
+                bool completed = op.TryCompleteAsync(_fileDescriptor, forceComplete: true);
                 Debug.Assert(completed);
                 sendQueue.Dequeue();
             }
@@ -477,7 +477,7 @@ namespace System.Net.Sockets
             while (!receiveQueue.IsEmpty)
             {
                 TransferOperation op = receiveQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor, true);
+                bool completed = op.TryCompleteAsync(_fileDescriptor, forceComplete: true);
                 Debug.Assert(completed);
                 receiveQueue.Dequeue();
             }
@@ -1316,7 +1316,7 @@ namespace System.Net.Sockets
                     while (!receiveQueue.IsEmpty)
                     {
                         TransferOperation op = receiveQueue.Head;
-                        bool completed = op.TryCompleteAsync(_fileDescriptor, false);
+                        bool completed = op.TryCompleteAsync(_fileDescriptor, forceComplete: false);
                         Debug.Assert(completed);
                         receiveQueue.Dequeue();
                     }
@@ -1353,7 +1353,7 @@ namespace System.Net.Sockets
                         do
                         {
                             op = _acceptOrConnectQueue.Head;
-                            if (!op.TryCompleteAsync(_fileDescriptor, false))
+                            if (!op.TryCompleteAsync(_fileDescriptor, forceComplete: false))
                             {
                                 break;
                             }
@@ -1367,7 +1367,7 @@ namespace System.Net.Sockets
                         do
                         {
                             op = _receiveQueue.Head;
-                            if (!op.TryCompleteAsync(_fileDescriptor, false))
+                            if (!op.TryCompleteAsync(_fileDescriptor, forceComplete: false))
                             {
                                 break;
                             }
@@ -1395,7 +1395,7 @@ namespace System.Net.Sockets
                         do
                         {
                             op = _acceptOrConnectQueue.Head;
-                            if (!op.TryCompleteAsync(_fileDescriptor, false))
+                            if (!op.TryCompleteAsync(_fileDescriptor, forceComplete: false))
                             {
                                 break;
                             }
@@ -1409,7 +1409,7 @@ namespace System.Net.Sockets
                         do
                         {
                             op = _sendQueue.Head;
-                            if (!op.TryCompleteAsync(_fileDescriptor, false))
+                            if (!op.TryCompleteAsync(_fileDescriptor, forceComplete: false))
                             {
                                 break;
                             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -17,13 +17,6 @@ namespace System.Net.Sockets
     //     - This will require a new state for each queue, unregistred, to track whether or
     //       not the queue is currently registered to receive events
     // - Audit Close()-related code for the possibility of file descriptor recycling issues
-    //     - This will at least involve moving the call to SocketAsyncContext.Close() in
-    //       SafeCloseSocket to before the file descriptor is actually closed.
-    //         - This timing change will require adding a "forcible complete" flag to
-    //           AsyncOperation.TryCopmlete that completes the operation whether or not
-    //           the underlying system call returns EAGAIN/EINPROGRESS/EWOULDBLOCK.
-    //         - Note that this may be required regardless of file descriptor recycling in
-    //           order to match Winsock behavior, particularly with regards to error codes.
     //     - It might make sense to change _closeLock to a ReaderWriterLockSlim that is
     //       acquired for read by all public methods before attempting a completion and
     //       acquired for write by Close() and HandlEvents()
@@ -88,7 +81,7 @@ namespace System.Net.Sockets
                 return DoTryComplete(fileDescriptor);
             }
 
-            public bool TryCompleteAsync(int fileDescriptor)
+            public bool TryCompleteAsync(int fileDescriptor, bool forceComplete)
             {
                 int state = Interlocked.CompareExchange(ref _state, (int)State.Running, (int)State.Waiting);
                 if (state == (int)State.Cancelled)
@@ -98,7 +91,14 @@ namespace System.Net.Sockets
                 }
                 Debug.Assert(state != (int)State.Complete && state != (int)State.Running);
 
-                if (DoTryComplete(fileDescriptor))
+                bool completed = DoTryComplete(fileDescriptor);
+                if (!completed && forceComplete)
+                {
+                    ErrorCode = SocketError.OperationAborted;
+                    completed = true;
+                }
+
+                if (completed)
                 {
                     var @event = CallbackOrEvent as ManualResetEventSlim;
                     if (@event != null)
@@ -364,6 +364,8 @@ namespace System.Net.Sockets
                 _handle = GCHandle.Alloc(this, GCHandleType.Normal);
             }
 
+            events |= _registeredEvents;
+
             Interop.Error errorCode;
             if (!_engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode))
             {
@@ -376,7 +378,7 @@ namespace System.Net.Sockets
                 throw new Exception(string.Format("SocketAsyncContext.Register: {0}", errorCode));
             }
 
-            _registeredEvents |= events;
+            _registeredEvents = events;
         }
 
         private void UnregisterRead()
@@ -393,7 +395,6 @@ namespace System.Net.Sockets
             {
                 Interop.Error errorCode;
                 bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode);
-
                 if (unregistered)
                 {
                     _registeredEvents = events;
@@ -418,13 +419,6 @@ namespace System.Net.Sockets
             Interop.Error errorCode;
             bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, SocketAsyncEvents.None, _handle, out errorCode);
             _registeredEvents = (SocketAsyncEvents)(-1);
-
-            // We may receive any of the errors below if _fileDescriptor has already been closed.
-            unregistered = unregistered ||
-                errorCode == Interop.Error.EBADF ||
-                errorCode == Interop.Error.ENOENT ||
-                errorCode == Interop.Error.EPERM;
-
             if (unregistered)
             {
                 _registeredEvents = SocketAsyncEvents.None;
@@ -465,7 +459,7 @@ namespace System.Net.Sockets
             while (!acceptOrConnectQueue.IsEmpty)
             {
                 AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                bool completed = op.TryCompleteAsync(_fileDescriptor, true);
                 Debug.Assert(completed);
                 acceptOrConnectQueue.Dequeue();
             }
@@ -474,7 +468,7 @@ namespace System.Net.Sockets
             while (!sendQueue.IsEmpty)
             {
                 SendReceiveOperation op = sendQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                bool completed = op.TryCompleteAsync(_fileDescriptor, true);
                 Debug.Assert(completed);
                 sendQueue.Dequeue();
             }
@@ -483,7 +477,7 @@ namespace System.Net.Sockets
             while (!receiveQueue.IsEmpty)
             {
                 TransferOperation op = receiveQueue.Head;
-                bool completed = op.TryCompleteAsync(_fileDescriptor);
+                bool completed = op.TryCompleteAsync(_fileDescriptor, true);
                 Debug.Assert(completed);
                 receiveQueue.Dequeue();
             }
@@ -1322,7 +1316,7 @@ namespace System.Net.Sockets
                     while (!receiveQueue.IsEmpty)
                     {
                         TransferOperation op = receiveQueue.Head;
-                        bool completed = op.TryCompleteAsync(_fileDescriptor);
+                        bool completed = op.TryCompleteAsync(_fileDescriptor, false);
                         Debug.Assert(completed);
                         receiveQueue.Dequeue();
                     }
@@ -1359,7 +1353,7 @@ namespace System.Net.Sockets
                         do
                         {
                             op = _acceptOrConnectQueue.Head;
-                            if (!op.TryCompleteAsync(_fileDescriptor))
+                            if (!op.TryCompleteAsync(_fileDescriptor, false))
                             {
                                 break;
                             }
@@ -1373,7 +1367,7 @@ namespace System.Net.Sockets
                         do
                         {
                             op = _receiveQueue.Head;
-                            if (!op.TryCompleteAsync(_fileDescriptor))
+                            if (!op.TryCompleteAsync(_fileDescriptor, false))
                             {
                                 break;
                             }
@@ -1401,7 +1395,7 @@ namespace System.Net.Sockets
                         do
                         {
                             op = _acceptOrConnectQueue.Head;
-                            if (!op.TryCompleteAsync(_fileDescriptor))
+                            if (!op.TryCompleteAsync(_fileDescriptor, false))
                             {
                                 break;
                             }
@@ -1415,7 +1409,7 @@ namespace System.Net.Sockets
                         do
                         {
                             op = _sendQueue.Head;
-                            if (!op.TryCompleteAsync(_fileDescriptor))
+                            if (!op.TryCompleteAsync(_fileDescriptor, false))
                             {
                                 break;
                             }


### PR DESCRIPTION
- Reorder SocketAsyncContext.Close() w.r.t. libc.close() in order to
  prevent file descriptor recycling issues. Previously, Close() ran
  the risk of modifying a different socket's event registration if
  it raced with the creation of a new socket that happened to recycle
  the closed file descriptor.
- Fix a bug in SocketAsyncContext.Register() that was causing
  unintentional event unregistration.
