### PR TITLE
Fix some issues with OS X.

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -12,6 +12,8 @@ namespace System.Net.Sockets.Tests
         //       once this code is merged into corefx/master.
         private const int DummyDualModeV6Issue = 123456;
         private const int DummyErrorMismatchIssue = 123457;
+        private const int DummyOSXPacketInfoIssue = 123458;
+        private const int DummyOSXDualModePacketInfoIssue = 123459;
 
         private const int TestPortBase = 8200;  // to 8300
         private readonly ITestOutputHelper _log;
@@ -1443,12 +1445,14 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveFromV4BoundToSpecificV4_Success()
         {
             ReceiveFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 202);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveFromV4BoundToAnyV4_Success()
         {
             ReceiveFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 203);
@@ -1677,6 +1681,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveFromAsyncV4BoundToAnyV4_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 223);
@@ -1801,36 +1806,42 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact] // Base case
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveMessageFromV4BoundToSpecificMappedV4_Success()
         {
             ReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, TestPortBase + 232);
         }
 
         [Fact] // Base case
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveMessageFromV4BoundToAnyMappedV4_Success()
         {
             ReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback, TestPortBase + 233);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveMessageFromV4BoundToSpecificV4_Success()
         {
             ReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 234);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveMessageFromV4BoundToAnyV4_Success()
         {
             ReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 235);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveMessageFromV6BoundToSpecificV6_Success()
         {
             ReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 236);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveMessageFromV6BoundToAnyV6_Success()
         {
             ReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 237);
@@ -1862,6 +1873,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void ReceiveMessageFromV4BoundToAnyV6_Success()
         {
             ReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 241);
@@ -1949,36 +1961,42 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact] // Base case
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToSpecificMappedV4_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, TestPortBase + 252);
         }
 
         [Fact] // Base case
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToAnyMappedV4_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback, TestPortBase + 253);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToSpecificV4_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 254);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToAnyV4_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 255);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void BeginReceiveMessageFromV6BoundToSpecificV6_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 256);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void BeginReceiveMessageFromV6BoundToAnyV6_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 257);
@@ -2010,6 +2028,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToAnyV6_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 261);
@@ -2090,36 +2109,42 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact] // Base case
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToSpecificMappedV4_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, TestPortBase + 272);
         }
 
         [Fact] // Base case
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToAnyMappedV4_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback, TestPortBase + 273);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToSpecificV4_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback, TestPortBase + 274);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToAnyV4_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 275);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveMessageFromAsyncV6BoundToSpecificV6_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, TestPortBase + 276);
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveMessageFromAsyncV6BoundToAnyV6_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback, TestPortBase + 277);
@@ -2151,6 +2176,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXDualModePacketInfoIssue, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToAnyV6_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback, TestPortBase + 281);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/LingerStateTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/LingerStateTest.cs
@@ -4,6 +4,9 @@ namespace System.Net.Sockets.Tests
 {
     public class LingerStateTest
     {
+        // This is a stand-in for an issue to be filed when this code is merged into corefx.
+        private const int DummyOSXLingerStateIssue = 123456;
+
         private void TestLingerState_Success(Socket sock, bool enabled, int lingerTime)
         {
             sock.LingerState = new LingerOption(enabled, lingerTime);
@@ -20,6 +23,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXLingerStateIssue, PlatformID.OSX)]
         public void Socket_LingerState_Boundaries_CorrectBehavior()
         {
             Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ReceiveMessageFrom.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ReceiveMessageFrom.cs
@@ -4,9 +4,13 @@ namespace System.Net.Sockets.Tests
 {
     public class ReceiveMessageFrom
     {
+        // This is a stand-in for an issue to be filed when this code is merged into corefx.
+        private const int DummyOSXPacketInfoIssue = 123456;
+
         private const int TestPortBase = 8060;
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void Success()
         {
             if (Socket.OSSupportsIPv4)

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ReceiveMessageFromAsync.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ReceiveMessageFromAsync.cs
@@ -7,6 +7,9 @@ namespace System.Net.Sockets.Tests
 {
     public class ReceiveMessageFromAsync
     {
+        // This is a stand-in for an issue to be filed when this code is merged into corefx.
+        private const int DummyOSXPacketInfoIssue = 123456;
+
         private const int TestPortBase = 8090;
 
         public void OnCompleted(object sender, SocketAsyncEventArgs args)
@@ -16,6 +19,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void Success()
         {
             ManualResetEvent completed = new ManualResetEvent(false);

--- a/src/System.Net.Sockets.Legacy/tests/PerformanceTests/SocketPerformanceAPMTests.cs
+++ b/src/System.Net.Sockets.Legacy/tests/PerformanceTests/SocketPerformanceAPMTests.cs
@@ -4,21 +4,14 @@ using System.Net.Test.Common;
 using Xunit;
 using Xunit.Abstractions;
 
-//
-// expectedMilliseconds has been computed as 10x the observed execution time on a Z420 machine using a RET version
-// of the runtime.
-// Known DEBUG-only (CHK builds) code overhead will cause the tests to execute approximatively 50x slower in ProjectK 
-// and about 10x slower on N.
-// Experimental results show that ARM executions (chk or ret) can be 31x slower.
-// 
-
 namespace System.Net.Sockets.Performance.Tests
 {
     [Trait("Perf", "true")]
     public class SocketPerformanceAPMTests
     {
-        private const int TestPortBase = 8300;
+        private const int DummyOSXPerfIssue = 123456;
 
+        private const int TestPortBase = 8300;
         private readonly ITestOutputHelper _log;
 
         public SocketPerformanceAPMTests(ITestOutputHelper output)
@@ -50,6 +43,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPerfIssue, PlatformID.OSX)]
         public void SocketPerformance_MultipleSocketClientAPM_LocalHostServerAPM()
         {
             int port = TestPortBase + 1;
@@ -96,6 +90,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPerfIssue, PlatformID.OSX)]
         public void SocketPerformance_MultipleSocketClientAPM_LocalHostServerAsync()
         {
             int port = TestPortBase + 3;
@@ -142,6 +137,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPerfIssue, PlatformID.OSX)]
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAPM()
         {
             int port = TestPortBase + 5;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -5621,11 +5621,14 @@ namespace System.Net.Sockets
                 IPEndPoint ipEndPoint = _rightEndPoint as IPEndPoint;
                 IPAddress boundAddress = (ipEndPoint != null ? ipEndPoint.Address : null);
                 Debug.Assert(boundAddress != null, "Not Bound");
-                if (_addressFamily == AddressFamily.InterNetwork
-                    || (boundAddress != null && IsDualMode
-                        && (boundAddress.IsIPv4MappedToIPv6 || boundAddress.Equals(IPAddress.IPv6Any))))
+                if (_addressFamily == AddressFamily.InterNetwork)
                 {
                     SetSocketOption(SocketOptionLevel.IP, SocketOptionName.PacketInformation, true);
+                }
+
+                if ((boundAddress != null && IsDualMode && (boundAddress.IsIPv4MappedToIPv6 || boundAddress.Equals(IPAddress.IPv6Any))))
+                {
+                    SocketPal.SetReceivingDualModeIPv4PacketInformation(this);
                 }
 
                 if (_addressFamily == AddressFamily.InterNetworkV6

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Linux.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Linux.cs
@@ -22,5 +22,10 @@ namespace System.Net.Sockets
             int err = Interop.libc.connect(fileDescriptor, sockAddr, (uint)socketAddressLen);
             Debug.Assert(err == 0, "TryCompleteConnect: failed to disassociate socket after failed connect()");
         }
+
+        public static void SetReceivingDualModeIPv4PacketInformation(Socket socket)
+        {
+            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.PacketInformation, true);
+        }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.OSX.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.OSX.cs
@@ -8,5 +8,12 @@ namespace System.Net.Sockets
     internal static partial class SocketPal
     {
         public const bool SupportsMultipleConnectAttempts = false;
+
+        public static void SetReceivingDualModeIPv4PacketInformation(Socket socket)
+        {
+            // NOTE: OS X does not support receiving IPv4 packet information for a dual-stack IPv6 socket. Instead,
+            //       this information is extracted from IPv6 packet information when possible. As a result, this call
+            //       is a no-op.
+        }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -512,6 +512,11 @@ namespace System.Net.Sockets
             return errorCode == SocketError.SocketError ? GetLastSocketError() : SocketError.Success;
         }
 
+        public static void SetReceivingDualModeIPv4PacketInformation(Socket socket)
+        {
+            socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.PacketInformation, true);
+        }
+
         public static SocketError SetMulticastOption(SafeCloseSocket handle, SocketOptionName optionName, MulticastOption optionValue)
         {
             Interop.Winsock.IPMulticastRequest ipmr = new Interop.Winsock.IPMulticastRequest();

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -14,6 +14,7 @@ namespace System.Net.Sockets.Tests
         // TODO: This is a stand-in for an issue that will need to be filed when this code is
         //       merged into corefx.
         private const int DummySendToThrowsIssue = 123456;
+        private const int DummyOSXPacketInfoIssue = 123457;
 
         private const int TestPortBase = 8200;  // to 8300
         private readonly ITestOutputHelper _log;
@@ -489,6 +490,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPacketInfoIssue, PlatformID.OSX)]
         public void ReceiveFromAsyncV4BoundToAnyV4_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback, TestPortBase + 53);

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -4,19 +4,13 @@ using System.Net.Test.Common;
 using Xunit;
 using Xunit.Abstractions;
 
-//
-// expectedMilliseconds has been computed as 10x the observed execution time on a Z420 machine using a RET version
-// of the runtime.
-// Known DEBUG-only (CHK builds) code overhead will cause the tests to execute approximatively 50x slower in ProjectK 
-// and about 10x slower on N.
-// Experimental results show that ARM executions (chk or ret) can be 31x slower.
-// 
-
 namespace System.Net.Sockets.Performance.Tests
 {
     [Trait("Perf", "true")]
     public class SocketPerformanceAsyncTests
     {
+        private const int DummyOSXPerfIssue = 123456;
+
         public const int TestPortBase = 8300;
         private readonly ITestOutputHelper _log;
 
@@ -49,6 +43,7 @@ namespace System.Net.Sockets.Performance.Tests
         }
 
         [Fact]
+        [ActiveIssue(DummyOSXPerfIssue, PlatformID.OSX)]
         public void SocketPerformance_MultipleSocketClientAsync_LocalHostServerAsync()
         {
             int port = TestPortBase + 7;


### PR DESCRIPTION
- "Fix" dual-mode IPv4 packet info for OS X. Unfortunately, OS X does not support receiving this information.
- Exclude tests that are failing on OS X.
