### PR TITLE
Fix some issues with the Sockets perf tests.

### DIFF
--- a/src/Common/tests/System.Net/Sockets/Performance/SocketTestClient.cs
+++ b/src/Common/tests/System.Net/Sockets/Performance/SocketTestClient.cs
@@ -101,12 +101,20 @@ namespace System.Net.Sockets.Performance.Tests
             }
         }
 
-        public abstract void Connect(Action onConnectCallback);
+        public abstract void Connect(Action<SocketError> onConnectCallback);
 
-        private void OnConnect()
+        private void OnConnect(SocketError error)
         {
             _timeConnect.Stop();
-            _log.WriteLine(this.GetHashCode() + " OnConnect() _timeConnect={0}", _timeConnect.ElapsedMilliseconds);
+            _log.WriteLine(this.GetHashCode() + " OnConnect({0}) _timeConnect={1}", error, _timeConnect.ElapsedMilliseconds);
+
+            // TODO: an error should fail the test.
+            if (error != SocketError.Success)
+            {
+                _timeClose.Start();
+                Close(OnClose);
+                return;
+            }
 
             _timeSendRecv.Start();
 
@@ -118,12 +126,20 @@ namespace System.Net.Sockets.Performance.Tests
             Receive(OnReceive);
         }
 
-        public abstract void Send(Action<int> onSendCallback);
+        public abstract void Send(Action<int, SocketError> onSendCallback);
 
         // Called when the entire _sendBuffer has been sent.
-        private void OnSend(int bytesSent)
+        private void OnSend(int bytesSent, SocketError error)
         {
-            _log.WriteLine(this.GetHashCode() + " OnSend({0})", bytesSent);
+            _log.WriteLine(this.GetHashCode() + " OnSend({0}, {1})", bytesSent, error);
+
+            // TODO: an error should fail the test.
+            if (error != SocketError.Success)
+            {
+                _timeClose.Start();
+                Close(OnClose);
+                return;
+            }
 
             if (bytesSent == _sendBuffer.Length)
             {
@@ -151,13 +167,21 @@ namespace System.Net.Sockets.Performance.Tests
             //TODO: _s.Shutdown(SocketShutdown.Send);
         }
 
-        public abstract void Receive(Action<int> onReceiveCallback);
+        public abstract void Receive(Action<int, SocketError> onReceiveCallback);
 
         // Called when the entire _recvBuffer has been received.
-        private void OnReceive(int receivedBytes)
+        private void OnReceive(int receivedBytes, SocketError error)
         {
-            _log.WriteLine(this.GetHashCode() + " OnSend({0})", receivedBytes);
+            _log.WriteLine(this.GetHashCode() + " OnSend({0}, {1})", receivedBytes, error);
             _recvBufferIndex += receivedBytes;
+
+            // TODO: an error should fail the test.
+            if (error != SocketError.Success)
+            {
+                _timeClose.Start();
+                Close(OnClose);
+                return;
+            }
 
             if (_recvBufferIndex == _recvBuffer.Length)
             {

--- a/src/Common/tests/System.Net/Sockets/Performance/SocketTestClientAsync.cs
+++ b/src/Common/tests/System.Net/Sockets/Performance/SocketTestClientAsync.cs
@@ -24,7 +24,7 @@ namespace System.Net.Sockets.Performance.Tests
             recvEventArgs.Completed += IO_Complete;
         }
         
-        public override void Connect(Action onConnectCallback)
+        public override void Connect(Action<SocketError> onConnectCallback)
         {
             var connectEventArgs = new SocketAsyncEventArgs();
             connectEventArgs.RemoteEndPoint = _endpoint;
@@ -32,7 +32,6 @@ namespace System.Net.Sockets.Performance.Tests
             connectEventArgs.Completed += OnConnect;
 
             bool willRaiseEvent = _s.ConnectAsync(connectEventArgs);
-
             if (!willRaiseEvent)
             {
                 ProcessConnect(connectEventArgs);
@@ -46,38 +45,38 @@ namespace System.Net.Sockets.Performance.Tests
 
         private void ProcessConnect(SocketAsyncEventArgs e)
         {
-            if (e.SocketError != SocketError.Success)
-            {
-                return;
-            }
-
-            Action callback = (Action)e.UserToken;
-            callback();
+            Action<SocketError> callback = (Action<SocketError>)e.UserToken;
+            callback(e.SocketError);
         }
 
-        public override void Send(Action<int> onSendCallback)
+        public override void Send(Action<int, SocketError> onSendCallback)
         {
             sendEventArgs.SetBuffer(_sendBuffer, _sendBufferIndex, _sendBuffer.Length - _sendBufferIndex);
             sendEventArgs.UserToken = onSendCallback;
-            _s.SendAsync(sendEventArgs);
+
+            bool willRaiseEvent = _s.SendAsync(sendEventArgs);
+            if (!willRaiseEvent)
+            {
+                IO_Complete(this, sendEventArgs);
+            }
         }
 
-        public override void Receive(Action<int> onReceiveCallback)
+        public override void Receive(Action<int, SocketError> onReceiveCallback)
         {
             recvEventArgs.SetBuffer(_recvBuffer, _recvBufferIndex, _recvBuffer.Length - _recvBufferIndex);
             recvEventArgs.UserToken = onReceiveCallback;
-            _s.ReceiveAsync(recvEventArgs);            
+
+            bool willRaiseEvent = _s.ReceiveAsync(recvEventArgs);
+            if (!willRaiseEvent)
+            {
+                IO_Complete(this, recvEventArgs);
+            }
         }
 
         private void IO_Complete(object sender, SocketAsyncEventArgs e)
         {
-            if (e.SocketError != SocketError.Success)
-            {
-                return;
-            }
-
-            Action<int> callback = (Action<int>)e.UserToken;
-            callback(e.BytesTransferred);
+            Action<int, SocketError> callback = (Action<int, SocketError>)e.UserToken;
+            callback(e.BytesTransferred, e.SocketError);
         }
 
         public override void Close(Action onCloseCallback)

--- a/src/System.Net.Sockets.Legacy/tests/PerformanceTests/SocketPerformanceAPMTests.cs
+++ b/src/System.Net.Sockets.Legacy/tests/PerformanceTests/SocketPerformanceAPMTests.cs
@@ -14,7 +14,7 @@ namespace System.Net.Sockets.Performance.Tests
     {
         private const int DummyOSXPerfIssue = 123456;
 
-        private const int TestPortBase = 8300;
+        private const int TestPortBase = 9300;
         private readonly ITestOutputHelper _log;
 
         public SocketPerformanceAPMTests(ITestOutputHelper output)

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketPerformanceAsyncTests.cs
@@ -14,7 +14,7 @@ namespace System.Net.Sockets.Performance.Tests
     {
         private const int DummyOSXPerfIssue = 123456;
 
-        public const int TestPortBase = 7300;
+        public const int TestPortBase = 9310;
         private readonly ITestOutputHelper _log;
 
         public SocketPerformanceAsyncTests(ITestOutputHelper output)

--- a/src/System.Net.Sockets/tests/PerformanceTests/SocketTestClientAPMMock.cs
+++ b/src/System.Net.Sockets/tests/PerformanceTests/SocketTestClientAPMMock.cs
@@ -21,17 +21,17 @@ namespace System.Net.Sockets.Performance.Tests
             throw new NotSupportedException();
         }
 
-        public override void Connect(Action onConnectCallback)
+        public override void Connect(Action<SocketError> onConnectCallback)
         {
             throw new NotSupportedException();
         }
 
-        public override void Receive(Action<int> onReceiveCallback)
+        public override void Receive(Action<int, SocketError> onReceiveCallback)
         {
             throw new NotSupportedException();
         }
 
-        public override void Send(Action<int> onSendCallback)
+        public override void Send(Action<int, SocketError> onSendCallback)
         {
             throw new NotSupportedException();
         }


### PR DESCRIPTION
Operation failure was not properly handled, resulting in test hangs. This also adjusts the ports for the perf tests to avoid conflicts with other tests.
