### PR TITLE
Fix a bug in SocketAsyncContext.TryComplete.

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -91,11 +91,15 @@ namespace System.Net.Sockets
                 }
                 Debug.Assert(state != (int)State.Complete && state != (int)State.Running);
 
-                bool completed = DoTryComplete(fileDescriptor);
-                if (!completed && forceComplete)
+                bool completed;
+                if (forceComplete)
                 {
                     ErrorCode = SocketError.OperationAborted;
                     completed = true;
+                }
+                else
+                {
+                    completed = DoTryComplete(fileDescriptor);
                 }
 
                 if (completed)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/_MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/_MultipleConnectAsync.cs
@@ -254,6 +254,7 @@ namespace System.Net.Sockets
                     {
                         // The connect attempt on the user's socket failed. Return the corresponding error.
                         exception = new SocketException((int)args.SocketError);
+                        _state = State.Completed;
                     }
                 }
             }


### PR DESCRIPTION
If forceComplete is true, don't attempt an actual completion. This is consistent with Winsock.
