### PR TITLE
Fix two accept() bugs.

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -908,12 +908,13 @@ namespace System.Net.Sockets
                 }
                 else
                 {
-                    Interop.Sys.Close(fd);
                     errorCode = GetLastSocketError();
                     acceptedFd = -1;
+                    Interop.Sys.Close(fd);
                 }
                 return true;
             }
+
             acceptedFd = -1;
 
             Interop.Error errno = Interop.Sys.GetLastError();


### PR DESCRIPTION
- A Close() was misorderd w.r.t. GetLastError() on an accept() failure
  path.
- The accepted file descriptor was not being properly set to -1 on a
  different failure path.
