### PR TITLE
Fix a broken assumption in the Socket tests.

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Test.Common;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Xunit;
 using Xunit.Abstractions;
@@ -2304,6 +2305,7 @@ namespace System.Net.Sockets.Tests
                 }
                 catch (SocketException) 
                 {
+                    Task.Delay(100).Wait(); // Give the other end a chance to call Accept().
                     serverSocket.Dispose(); // Cancels the test
                 }
             }


### PR DESCRIPTION
SocketClient assumed that it was safe to dispose the server socket if
its call to Connect() failed. This is not necessarily the case, however:
the calls to Accept and Connect race, there is a chance that the dispose
happens before the call to Accept. In this case, the call to Accept will
throw ObjectDisposedException and fail the test. Work around this issue
by changing SocketClient to wait 100 milliseconds before disposing the
server socket.
