### PR TITLE
Adding TODO issue number to WebSockets.Client

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.WinRT.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.WinRT.cs
@@ -41,7 +41,7 @@ namespace System.Net.WebSockets
             }
             catch (Exception ex)
             {
-                // TODO: ** TFS BUILD IS BROKEN ** 
+                // TODO #4143: ** TFS BUILD IS BROKEN ** 
                 // This doesn't compile right now due to missing types 'WebErrorStatus' and 'RTWebSocketError'
                 // Commenting out for now to allow the build to resume.
                 //WebErrorStatus status = RTWebSocketError.GetStatus(ex.HResult);


### PR DESCRIPTION
Adding TODO tracking issue number (#4143) to fix the NetNative WebSocket.Client contract implementation.
